### PR TITLE
remove_asterisk_on_subdomain_wildcard

### DIFF
--- a/ngen/models/common/mixins.py
+++ b/ngen/models/common/mixins.py
@@ -389,8 +389,7 @@ class AddressModelMixin(models.Model):
 
         def create_address_object(self, address):
             # return address.replace('*','').strip().lower().split('/')[0]
-            a = address.replace(
-                '*', '').strip().strip('.').lower().split('/')[0]
+            a = address.replace('*', '').strip().strip('.').lower().split('/')[0]
             if a == '':
                 return '*'
             return a
@@ -419,7 +418,7 @@ class AddressModelMixin(models.Model):
         def network_string(self):
             if self.is_default():
                 return '*'
-            return f'*.{self.address}'
+            return f'{self.address}'
 
         def network_with_mask(self):
             return f'{self.address}/{self.address_mask()}'


### PR DESCRIPTION
This pull request attempts to remove the visualization of the asterisk on wildcard subdomains, such as `*.test.com`, changing it to `test.com`. However, it retains the asterisk on default subdomains (root tree) like `*` or `''` (empty).