### PR TITLE
Wildcard domain with * or .

### DIFF
--- a/ngen/fixtures/network.json
+++ b/ngen/fixtures/network.json
@@ -37,7 +37,7 @@
       "modified": "2021-12-05T15:12:43.420Z",
       "parent": null,
       "cidr": null,
-      "domain": "",
+      "domain": "*",
       "active": true,
       "type": "internal",
       "network_entity": null,

--- a/ngen/models/common/mixins.py
+++ b/ngen/models/common/mixins.py
@@ -229,17 +229,17 @@ class AddressModelMixin(models.Model):
                 self.address = self.AddressIpv6(self.cidr)
             self.cidr = self.address.sanitized()
             return self.address
-        elif self.domain != None:
+        elif self.domain:
             self.address = self.AddressDomain(self.domain)
             self.domain = self.address.sanitized()
             return self.address
         return None
 
     def validate_addresses(self):
-        if not self.address_value and not self.cidr and self.domain == None:
+        if not self.address_value and not self.cidr and not self.domain:
             msg = 'At least cidr or domain must be setted'
             raise ValidationError({'cidr': [msg], 'domain': [msg]})
-        elif self.cidr and self.domain != None:
+        elif self.cidr and self.domain:
             msg = 'cidr and domain are mutually exclusive'
             raise ValidationError(
                 {'address_value': [msg], 'cidr': [msg], 'domain': [msg]})
@@ -383,7 +383,7 @@ class AddressModelMixin(models.Model):
     class AddressDomain(Address):
 
         def address_mask(self):
-            if self.address in ['*', '']:
+            if self.address in ['*', '.']:
                 return 0
             return len(self.address.split('.'))
 

--- a/ngen/tests/api/test_events.py
+++ b/ngen/tests/api/test_events.py
@@ -213,7 +213,7 @@ class TestEvent(APITestCase):
             'feed': self.feed_url
         }
         response = self.client.post(self.url_list, data=json_data)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_event_post_with_cidr_empty_and_domain_empty(self):
         '''
@@ -229,7 +229,7 @@ class TestEvent(APITestCase):
             'feed': self.feed_url
         }
         response = self.client.post(self.url_list, data=json_data)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_event_post_with_cidr_wildcard_and_domain_empty(self):
         '''
@@ -238,6 +238,22 @@ class TestEvent(APITestCase):
         json_data = {
             'cidr': '0.0.0.0/0',
             'domain': '',
+            'notes': 'estas son notas',
+            'priority': self.priority_url,
+            'tlp': self.tlp_url,
+            'taxonomy': self.taxonomy_url,
+            'feed': self.feed_url
+        }
+        response = self.client.post(self.url_list, data=json_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_event_post_with_cidr_wildcard_and_domain_wildcard(self):
+        '''
+        This will test bad request Event POST
+        '''
+        json_data = {
+            'cidr': '0.0.0.0/0',
+            'domain': '*',
             'notes': 'estas son notas',
             'priority': self.priority_url,
             'tlp': self.tlp_url,


### PR DESCRIPTION
Now empty domain cannot be an "" (empty string). 

Wildcard domain must be `.` or `*`