### PR TITLE
Added matching event case creation and fix active template matching

### DIFF
--- a/ngen/models/common/mixins.py
+++ b/ngen/models/common/mixins.py
@@ -217,6 +217,19 @@ class AddressManager(NetManager):
     def parent_of(self, address: 'AddressModelMixin'):
         return self.parents_of(address)
 
+    def cidr_children_of(self, cidr: str):
+        return self.filter(cidr__net_contained_or_equal=cidr).order_by('cidr')
+
+    def domain_children_of(self, domain: str):
+        return self.filter(domain__endswith=domain).order_by('domain')
+
+    def children_of(self, address: 'AddressModelMixin'):
+        if address.cidr:
+            return self.cidr_children_of(str(address.address))
+        elif address.domain:
+            return self.domain_children_of(str(address.address))
+        return self.none()
+
     def defaults(self):
         return self.filter(Q(cidr__prefixlen=0) | Q(domain='*'))
 

--- a/ngen/serializers/case.py
+++ b/ngen/serializers/case.py
@@ -207,9 +207,14 @@ class CaseSerializerReducedWithEventsCount(CaseSerializerReduced):
 
 
 class CaseTemplateSerializer(AuditSerializerMixin):
+    matching_events_without_case = serializers.SerializerMethodField(read_only=True)
+
     class Meta:
         model = models.CaseTemplate
         fields = '__all__'
+
+    def get_matching_events_without_case(self, obj):
+        return obj.matching_events_without_case().count()
 
 
 class EvidenceSerializer(AuditSerializerMixin):


### PR DESCRIPTION
1. Added filter to Events `template_id` that match all events with template.
Example: `/api/event/?template_id=2`

 It can be mixed with `parent__isnull=true` & `case__isnull=true`.
Example: `/api/event/?parent__isnull=true&case__isnull=true&template_id=7`

2. Added field to template that count matching events without parent/case.
![image](https://github.com/CERTUNLP/ngen/assets/668847/b3e402b1-5d1f-496c-afff-64b782bdb52d)

3. Added action route `/api/template/<template_id>/create-cases/` that create cases based on events matching a template id. Returns 201 with Cases created by Template (could be empty list if no one matches).

4. Fixed missing matching template field `active` when new event create case based on template