### PR TITLE
force event reporter to current user

### DIFF
--- a/ngen/serializers/case.py
+++ b/ngen/serializers/case.py
@@ -96,6 +96,7 @@ class EventSerializer(MergeSerializerMixin, EvidenceSerializerMixin, AuditSerial
 
     def create(self, validated_data):
         artifacts = validated_data.pop('artifacts', [])
+        validated_data['reporter'] = self.context['request'].user
         event = super().create(validated_data)
         for artifact in artifacts:
             artifact_obj = models.Artifact.objects.get(pk=artifact.pk)


### PR DESCRIPTION
Reporter must be always current user of created event and cannot be changed.

![imagen](https://github.com/CERTUNLP/ngen/assets/668847/94c3acf5-8bbc-4033-91ac-cd3bae8141fb)

Waiting to frontend to make this field not editable @gabisuarez 