### PR TITLE
Feature/components ordering

### DIFF
--- a/ngen/models/case.py
+++ b/ngen/models/case.py
@@ -448,7 +448,15 @@ class CaseTemplate(AuditModelMixin, PriorityModelMixin, AddressModelMixin, Valid
         return Case.objects.create(tlp=self.case_tlp, lifecycle=self.case_lifecycle, state=self.case_state,
                                    casetemplate_creator=self, events=events)
 
+    @property
     def matching_events_without_case(self):
+        return self.get_matching_events_without_case().count()
+
+    @matching_events_without_case.setter
+    def matching_events_without_case(self, value):
+        pass
+
+    def get_matching_events_without_case(self):
         return Event.objects.children_of(self).filter(case__isnull=True, taxonomy=self.event_taxonomy,
                                                       feed=self.event_feed)
 

--- a/ngen/models/case.py
+++ b/ngen/models/case.py
@@ -449,11 +449,11 @@ class CaseTemplate(AuditModelMixin, PriorityModelMixin, AddressModelMixin, Valid
                                    casetemplate_creator=self, events=events)
 
     @property
-    def matching_events_without_case(self):
+    def matching_events_without_case_count(self):
         return self.get_matching_events_without_case().count()
 
-    @matching_events_without_case.setter
-    def matching_events_without_case(self, value):
+    @matching_events_without_case_count.setter
+    def matching_events_without_case_count(self, value):
         pass
 
     def get_matching_events_without_case(self):
@@ -461,7 +461,7 @@ class CaseTemplate(AuditModelMixin, PriorityModelMixin, AddressModelMixin, Valid
                                                       feed=self.event_feed)
 
     def create_cases_for_matching_events(self):
-        return [self.create_case([event]) for event in self.matching_events_without_case()]
+        return [self.create_case([event]) for event in self.get_matching_events_without_case()]
 
     def __str__(self):
         return str(self.id)

--- a/ngen/models/common/mixins.py
+++ b/ngen/models/common/mixins.py
@@ -230,6 +230,22 @@ class AddressManager(NetManager):
             return self.domain_children_of(str(address.address))
         return self.none()
 
+    def children_of_cidr(self, cidr: str):
+        return self.cidr_children_of(cidr)
+
+    def children_of_domain(self, domain: str):
+        return self.domain_children_of(domain)
+
+    # def children_of_cidr_or_domain(self, cidr: str, domain: str):
+    #     if cidr:
+    #         return self.cidr_children_of(cidr)
+    #     elif domain:
+    #         return self.domain_children_of(domain)
+    #     return self.none()
+    #
+    def children_of_cidr_or_domain(self, cidr: str, domain: str):
+        return self.children_of_cidr(cidr) | self.children_of_domain(domain)
+
     def defaults(self):
         return self.filter(Q(cidr__prefixlen=0) | Q(domain='*'))
 

--- a/ngen/serializers/case.py
+++ b/ngen/serializers/case.py
@@ -236,14 +236,11 @@ class CaseSerializerReducedWithEventsCount(CaseSerializerReduced):
 
 
 class CaseTemplateSerializer(AuditSerializerMixin):
-    matching_events_without_case = serializers.SerializerMethodField(read_only=True)
+    matching_events_without_case = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = models.CaseTemplate
         fields = '__all__'
-
-    def get_matching_events_without_case(self, obj):
-        return obj.matching_events_without_case().count()
 
 
 class EvidenceSerializer(AuditSerializerMixin):

--- a/ngen/serializers/case.py
+++ b/ngen/serializers/case.py
@@ -236,7 +236,7 @@ class CaseSerializerReducedWithEventsCount(CaseSerializerReduced):
 
 
 class CaseTemplateSerializer(AuditSerializerMixin):
-    matching_events_without_case = serializers.IntegerField(read_only=True)
+    matching_events_without_case_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = models.CaseTemplate

--- a/ngen/views/case.py
+++ b/ngen/views/case.py
@@ -63,7 +63,7 @@ class CaseTemplateViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = super().get_queryset()
         # Ugly but necessary to order by a subquery? Can be moved to a custom manager?
-        ordering = self.request.query_params.get('ordering', None)
+        ordering = self.request.query_params.get('ordering', '')
         if 'matching_events_without_case_count' in ordering:
             subquery = models.Event.objects.children_of_cidr_or_domain(
                 cidr=OuterRef('cidr'), domain=OuterRef('domain')

--- a/ngen/views/case.py
+++ b/ngen/views/case.py
@@ -66,9 +66,10 @@ class CaseTemplateViewSet(viewsets.ModelViewSet):
         ordering = self.request.query_params.get('ordering', None)
         if ordering == 'matching_events_without_case':
             subquery = models.Event.objects.filter(
-                case=None, taxonomy=OuterRef('event_taxonomy'), domain=OuterRef('domain'), cidr=OuterRef('cidr')
-            ).values('id').annotate(total=Count('id')).values('total')
-            queryset = queryset.annotate(matching_events_without_case=Subquery(subquery))
+                case=None, taxonomy=OuterRef('event_taxonomy'), feed=OuterRef('event_feed'),
+                domain=OuterRef('domain'), cidr=OuterRef('cidr')
+            ).values('id').annotate(total=Count('id')).values('total')[:1]
+            queryset = queryset.annotate(matching_events_without_case=Subquery(subquery)).order_by('matching_events_without_case')
         return queryset
 
 

--- a/ngen/views/case.py
+++ b/ngen/views/case.py
@@ -46,7 +46,7 @@ class CaseViewSet(viewsets.ModelViewSet):
 
 
 class CaseTemplateViewSet(viewsets.ModelViewSet):
-    queryset = models.CaseTemplate.objects.all().order_by("id")
+    queryset = models.CaseTemplate.objects.all()
     filter_backends = [
         filters.SearchFilter,
         django_filters.rest_framework.DjangoFilterBackend,
@@ -55,7 +55,7 @@ class CaseTemplateViewSet(viewsets.ModelViewSet):
     search_fields = ["cidr", "domain", "address_value"]
     filterset_class = CaseTemplateFilter
     ordering_fields = ["id", "created", "modified", "cidr", "domain", "priority", "taxonomy",
-                       "matching_events_without_case"]
+                       "matching_events_without_case2"]
     serializer_class = serializers.CaseTemplateSerializer
     permission_classes = [permissions.IsAuthenticated]
 
@@ -64,12 +64,15 @@ class CaseTemplateViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         # Ugly but necessary to order by a subquery? Can be moved to a custom manager?
         ordering = self.request.query_params.get('ordering', None)
-        if ordering == 'matching_events_without_case':
+        if ordering == 'matching_events_without_case2':
             subquery = models.Event.objects.filter(
                 case=None, taxonomy=OuterRef('event_taxonomy'), feed=OuterRef('event_feed'),
                 domain=OuterRef('domain'), cidr=OuterRef('cidr')
             ).values('id').annotate(total=Count('id')).values('total')[:1]
-            queryset = queryset.annotate(matching_events_without_case=Subquery(subquery)).order_by('matching_events_without_case')
+            queryset = queryset.annotate(matching_events_without_case2=Subquery(subquery)).order_by('matching_events_without_case2')
+            # only matching events without case and pk
+            # queryset = queryset.filter(matching_events_without_case2__gt=0)
+            # print(queryset.query)
         return queryset
 
 

--- a/ngen/views/taxonomy.py
+++ b/ngen/views/taxonomy.py
@@ -54,7 +54,7 @@ class TodoTaskViewSet(viewsets.ModelViewSet):
         filters.OrderingFilter
     ]
     search_fields = ['note', 'assigned_to__username']
-    ordering_fields = ['id', 'created', 'modified', 'completed', 'assigned_to', 'note']
+    ordering_fields = ['id', 'created', 'modified', 'completed', 'assigned_to', 'note', 'reports']
     serializer_class = serializers.TodoTaskSerializer
     permission_classes = [permissions.IsAuthenticated]
 

--- a/ngen/views/taxonomy.py
+++ b/ngen/views/taxonomy.py
@@ -14,7 +14,7 @@ class TaxonomyViewSet(viewsets.ModelViewSet):
     ]
     search_fields = ['name', 'description']
     filterset_class = TaxonomyFilter
-    ordering_fields = ['id', 'created', 'modified', 'name', "reports"]
+    ordering_fields = ['id', 'created', 'modified', 'name', 'reports']
     serializer_class = serializers.TaxonomySerializer
     permission_classes = [permissions.IsAuthenticated]
 


### PR DESCRIPTION
Solves #113  

- Added ordering fields on CaseTemplate:
        - event_taxonomy
        - event_feed
        - case_lifecycle
        - case_tlp
        - case_state
        - case_tlp__name
        - case_state__name
        - event_taxonomy__name
        - event_feed__name
        - matching_events_without_case_count

- Changed name for CaseTemplate from `matching_events_without_case` to `matching_events_without_case_count`
