### PR TITLE
Updated workflows for new docker compose version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      container_name: docker_ngen-django_1
+      container_name: docker-ngen-django-1
     steps:
     - uses: actions/checkout@v3
     - name: Build docker containers
       run: |
         cd docker
-        docker-compose build
-        docker-compose up -d
+        docker compose build
+        docker compose up -d
 
         max_retries=60
         retries=0


### PR DESCRIPTION
Old version was with `docker-compose` and now is `docker compose`, also container name uses all `-` and not `_` anymore.