### PR TITLE
Compatibility with sass 2.0.0

### DIFF
--- a/frontend/src/assets/scss/partials/_custom.scss
+++ b/frontend/src/assets/scss/partials/_custom.scss
@@ -1,3 +1,4 @@
+@use '_variables' as *;
 
 .pcoded-navbar.menupos-static {
   position: fixed;

--- a/frontend/src/assets/scss/partials/_general.scss
+++ b/frontend/src/assets/scss/partials/_general.scss
@@ -1,6 +1,9 @@
 /**  =====================
       Custom css start
 ==========================  **/
+@use 'sass:color';
+@use '_variables' as *;
+
 body {
   font-family: $theme-font-family;
   font-size: $theme-font-size;
@@ -333,7 +336,7 @@ p.text-muted {
     &:active,
     &:focus,
     &:hover {
-      background: transparentize($primary-color, 0.9);
+      background: color.adjust($primary-color, $alpha: -0.9);
 
       > a {
         background: transparent;

--- a/frontend/src/assets/scss/partials/_generic.scss
+++ b/frontend/src/assets/scss/partials/_generic.scss
@@ -1,6 +1,9 @@
 /**  =====================
       Generic-class css start
 ========================== **/
+@use 'sass:list';
+@use '_variables' as *;
+
 /*====== Padding , Margin css starts ======*/
 $i: 0;
 @while $i<=50 {
@@ -53,21 +56,21 @@ $i: 0;
 
 /*====== text-color, background color css starts ======*/
 @each $value in $color-name {
-  $i: index($color-name, $value);
+  $i: list.index($color-name, $value);
   .bg-#{$value} {
-    background: nth($color-color, $i);
+    background: list.nth($color-color, $i);
   }
   .text-#{$value} {
-    color: nth($color-color, $i);
+    color: list.nth($color-color, $i);
   }
 }
 
 /*====== text-color css ends ======*/
 /*====== Card top border css starts ======*/
 @each $value in $color-name {
-  $i: index($color-name, $value);
+  $i: list.index($color-name, $value);
   .card-border-#{$value} {
-    border-top: 4px solid nth($color-color, $i);
+    border-top: 4px solid list.nth($color-color, $i);
   }
 }
 

--- a/frontend/src/assets/scss/partials/_variables.scss
+++ b/frontend/src/assets/scss/partials/_variables.scss
@@ -3,6 +3,9 @@
 // =======================================
 /*
 */
+@use "sass:color";
+@use "sass:map";
+
 $header-height: 70px;
 $Menu-width: 264px;
 $Menu-collapsed-width: 80px;
@@ -47,16 +50,16 @@ $dark-layout-font: #adb7be;
 $menu-icon-color: $primary-color, #ff5252, #01a9ac, #9575cd, #23b7e5, $warning-color;
 // Header background
 $color-header-name: blue, red, purple, lightblue, dark;
-$color-header-color: $primary-color, #ff5252, #9575cd, #23b7e5, lighten($dark-layout, 7%);
+$color-header-color: $primary-color, #ff5252, #9575cd, #23b7e5, color.adjust($dark-layout, $lightness: 7%);
 // Menu background
 $color-menu-name: blue, red, purple, lightblue, dark;
-$color-menu-color: $primary-color, #ff5252, #9575cd, #23b7e5, lighten($dark-layout, 7%);
+$color-menu-color: $primary-color, #ff5252, #9575cd, #23b7e5, color.adjust($dark-layout, $lightness: 7%);
 // Active background color
 $color-active-name: blue, red, purple, lightblue, dark;
-$color-active-color: $primary-color, #ff5252, #9575cd, #23b7e5, lighten($dark-layout, 7%);
+$color-active-color: $primary-color, #ff5252, #9575cd, #23b7e5, color.adjust($dark-layout, $lightness: 7%);
 // Menu title color
 $color-title-name: blue, red, purple, lightblue, dark;
-$color-title-color: $primary-color, #ff5252, #9575cd, #23b7e5, lighten($dark-layout, 7%);
+$color-title-color: $primary-color, #ff5252, #9575cd, #23b7e5, color.adjust($dark-layout, $lightness: 7%);
 
 // layout-6 background color
 $layout-6-bg-color: #23b7e5;
@@ -76,18 +79,18 @@ $color-bt-color: $primary-color, $danger-color, $success-color, $warning-color, 
 $form-bg: #f0f3f6;
 
 $theme-colors: () !default;
-$theme-colors: map-merge(
-                (
-                        'primary': $primary-color,
-                        'secondary': $secondary-color,
-                        'success': $success-color,
-                        'info': $info-color,
-                        'warning': $warning-color,
-                        'danger': $danger-color,
-                        'light': $light-color,
-                        'dark': $dark-color
-                ),
-                $theme-colors
+$theme-colors: map.merge(
+    (
+        'primary': $primary-color,
+        'secondary': $secondary-color,
+        'success': $success-color,
+        'info': $info-color,
+        'warning': $warning-color,
+        'danger': $danger-color,
+        'light': $light-color,
+        'dark': $dark-color
+    ),
+    $theme-colors
 ); // Color contrast
 $yiq-contrasted-threshold: 200 !default;
 $yiq-dark-color: #37474f;

--- a/frontend/src/assets/scss/partials/menu/_menu-lite.scss
+++ b/frontend/src/assets/scss/partials/menu/_menu-lite.scss
@@ -1,4 +1,7 @@
 /* new logo start */
+@use 'sass:color';
+@use 'sass:list';
+@use '../_variables' as *;
 
 .b-brand {
   display: flex;
@@ -326,7 +329,7 @@
           }
 
           &.notification:hover {
-            background: transparentize($primary-color, 0.9);
+            background: color.adjust($primary-color, $alpha: -0.9);
           }
 
           p {
@@ -418,7 +421,7 @@
           &:active,
           &:focus,
           &:hover {
-            background: transparentize($primary-color, 0.9);
+            background: color.adjust($primary-color, $alpha: -0.9);
 
             > a {
               background: transparent;
@@ -793,7 +796,7 @@
   }
 
   .pcoded-submenu {
-    background: darken($header-dark-background, 3%);
+    background: color.adjust($header-dark-background, $lightness: 3%);
     padding: 15px 0;
   }
 
@@ -900,7 +903,7 @@
               left: calc(calc(#{$Menu-collapsed-width} / 2) - 3px);
               width: 1px;
               height: calc(100% - 49px);
-              background: transparentize($menu-dark-text-color, 0.8);
+              background: color.adjust($menu-dark-text-color, $alpha: -0.8);
             }
 
             li {
@@ -1080,7 +1083,7 @@
         }
 
         > a {
-          background: darken($menu-dark-background, 6%);
+          background: color.adjust($menu-dark-background, $lightness: 6%);
           color: #fff;
         }
       }
@@ -1369,11 +1372,11 @@
 /* temp SCSS for document */
 
 @each $value in $color-menu-name {
-  $i: index($color-menu-name, $value);
+  $i: list.index($color-menu-name, $value);
 
   .nav-link {
     &.active.h-#{'' + $value} {
-      background: nth($color-menu-color, $i) !important;
+      background: list.nth($color-menu-color, $i) !important;
     }
   }
 }

--- a/frontend/src/assets/scss/partials/mixins/_buttons.scss
+++ b/frontend/src/assets/scss/partials/mixins/_buttons.scss
@@ -1,13 +1,15 @@
 /* Button variants
  Easily pump out default styles, as well as :hover, :focus, :active,
  and disabled options for all buttons */
+@use 'sass:color';
+
 @mixin button-variant-pc(
   $background,
   $border,
-  $hover-background: darken($background, 7.5%),
-  $hover-border: darken($border, 10%),
-  $active-background: darken($background, 10%),
-  $active-border: darken($border, 12.5%)
+  $hover-background: color.adjust($background, $lightness: 7.5%),
+  $hover-border: color.adjust($border, $lightness: 10%),
+  $active-background: color.adjust($background, $lightness: 10%),
+  $active-border: color.adjust($border, $lightness: 12.5%)
 ) {
   color: color-yiq($background);
   background-color: $border;
@@ -63,11 +65,11 @@
 }
 
 @mixin button-glow-variant-pc($color, $color-hover: color-yiq($color), $active-background: $color, $active-border: $color) {
-  box-shadow: 0 1px 6px 2px transparentize($color, 0.44),
-  0 6px 11px 2px transparentize($color, 0.8);
+  box-shadow: 0 1px 6px 2px color.adjust($color, $alpha: -0.44),
+  0 6px 11px 2px color.adjust($color, $alpha: -0.8);
   &:hover {
-    box-shadow: 0 1px 4px 2px transparentize($color, 0.44),
-    0 4px 9px 2px transparentize($color, 0.9);
+    box-shadow: 0 1px 4px 2px color.adjust($color, $alpha: -0.44),
+    0 4px 9px 2px color.adjust($color, $alpha: -0.9);
   }
   &:not(:disabled):not(.disabled).active,
   &:not(:disabled):not(.disabled):active:focus,

--- a/frontend/src/assets/scss/partials/other/_chat.scss
+++ b/frontend/src/assets/scss/partials/other/_chat.scss
@@ -1,6 +1,8 @@
 /**  =====================
       Chatting css start
 ==========================  **/
+@use "sass:color";
+@use '../_variables' as *;
 
 .header-chat,
 .header-user-list {
@@ -69,7 +71,7 @@
 
     &.msg-open {
       &:after {
-        color: transparentize($primary-color, 0.9);
+        color: color.adjust($primary-color, $alpha: -0.9);
       }
     }
   }
@@ -107,7 +109,7 @@
     }
 
     &.active {
-      background: lighten($primary-color, 45%);
+      background: color.adjust($primary-color, $lightness: 45%);
     }
 
     .media-left {
@@ -173,7 +175,7 @@
 
   .h-list-body {
     height: 100%;
-    background: lighten($primary-color, 45%);
+    background: color.adjust($primary-color, $lightness: 45%);
   }
 
   .h-list-footer {
@@ -183,7 +185,7 @@
     right: 0;
     padding: 20px 15px;
     z-index: 10;
-    background: lighten($primary-color, 45%);
+    background: color.adjust($primary-color, $lightness: 45%);
 
     .input-group {
       background: #fff;

--- a/frontend/src/assets/scss/partials/theme-elements/_authentication.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_authentication.scss
@@ -1,6 +1,8 @@
 /**  =====================
       Authentication css start
 ==========================  **/
+@use '../_variables' as *;
+
 .auth-wrapper {
   position: relative;
   display: flex;

--- a/frontend/src/assets/scss/partials/theme-elements/_breadcrumb-pagination.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_breadcrumb-pagination.scss
@@ -2,6 +2,7 @@
       Breadcrumbs & Pagination css start
 ==========================  **/
 /* Breadcrumbs */
+@use '../_variables' as *;
 
 .breadcrumb {
   background-color: $theme-background;

--- a/frontend/src/assets/scss/partials/theme-elements/_button.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_button.scss
@@ -1,4 +1,5 @@
-@import '../mixins/buttons';
+@use '../mixins/buttons' as *;
+@use '../_variables' as *;
 
 /**  =====================
       Button css start

--- a/frontend/src/assets/scss/partials/theme-elements/_data-tables.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_data-tables.scss
@@ -1,6 +1,9 @@
 /**  =====================
       Data Tables css start
 ==========================  **/
+@use 'sass:color';
+@use '../_variables' as *;
+
 .table {
   color: #888;
 
@@ -42,7 +45,7 @@
 
 .table-striped {
   tbody tr:nth-of-type(2n + 1) {
-    background-color: transparentize($primary-color, 0.95);
+    background-color: color.adjust($primary-color, $alpha: -0.95);
   }
 }
 
@@ -51,7 +54,7 @@
 .table-hover {
   tbody tr {
     &:hover {
-      background-color: transparentize($primary-color, 0.95);
+      background-color: color.adjust($primary-color, $alpha: -0.95);
     }
   }
 }

--- a/frontend/src/assets/scss/partials/theme-elements/_form.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_form.scss
@@ -1,6 +1,7 @@
 /**  =====================
       Form Componant css start
 ==========================  **/
+@use '../_variables' as *;
 
 .custom-select,
 .form-control {

--- a/frontend/src/assets/scss/partials/theme-elements/_labels-badges.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_labels-badges.scss
@@ -1,6 +1,8 @@
 /**  =====================
       Label & Badges css start
 ==========================  **/
+@use 'sass:list';
+@use '../_variables' as *;
 
 .label {
   padding: 4px 10px;
@@ -9,10 +11,10 @@
   margin-right: 5px;
   margin-bottom: 5px;
   @each $value in $color-bt-name {
-    $i: index($color-bt-name, $value);
+    $i: list.index($color-bt-name, $value);
 
     &.label-#{$value} {
-      background: nth($color-bt-color, $i);
+      background: list.nth($color-bt-color, $i);
       color: #ffffff;
     }
   }

--- a/frontend/src/assets/scss/partials/theme-elements/_nav.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_nav.scss
@@ -1,3 +1,5 @@
+@use '../_variables' as *;
+
 .nav {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/assets/scss/partials/theme-elements/_progress.scss
+++ b/frontend/src/assets/scss/partials/theme-elements/_progress.scss
@@ -1,6 +1,9 @@
 /**  =====================
       Progress css start
 ==========================  **/
+@use 'sass:list';
+@use '../_variables' as *;
+
 @keyframes progress-bar-stripes {
   from {
     background-position: 16px 0;
@@ -23,11 +26,11 @@
     box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.3);
 
     @each $value in $color-name {
-      $i: index($color-name, $value);
+      $i: list.index($color-name, $value);
 
       &.progress-#{$value},
       &.bg-#{$value} {
-        background: nth($color-color, $i);
+        background: list.nth($color-color, $i);
       }
     }
 

--- a/frontend/src/assets/scss/partials/third-party/_third-party.scss
+++ b/frontend/src/assets/scss/partials/third-party/_third-party.scss
@@ -1,6 +1,6 @@
-@import 'react-perfect-scrollbar/dist/css/styles.css';
-@import 'ngx-perfect-scrollbar';
-@import 'react-bootstrap/react-bootstrap';
+@use 'react-perfect-scrollbar/dist/css/styles.css' as *;
+@use 'ngx-perfect-scrollbar' as *;
+@use 'react-bootstrap/react-bootstrap' as *;
 
 .pcoded-header .main-search .input-group-text {
   line-height: 1;

--- a/frontend/src/assets/scss/partials/third-party/react-bootstrap/react-bootstrap.scss
+++ b/frontend/src/assets/scss/partials/third-party/react-bootstrap/react-bootstrap.scss
@@ -1,1 +1,1 @@
-@import 'header';
+@use 'header' as *;

--- a/frontend/src/assets/scss/partials/widget/_widget.scss
+++ b/frontend/src/assets/scss/partials/widget/_widget.scss
@@ -1,3 +1,5 @@
+@use '../_variables' as *;
+
 .user-list {
   .table {
     td {

--- a/frontend/src/assets/scss/style.scss
+++ b/frontend/src/assets/scss/style.scss
@@ -20,39 +20,39 @@ File: style.css
         -   Invoice, Full Calender, File Upload,
 =================================================================================
 =================================================================================== */
-@import 'bootstrap/dist/css/bootstrap';
+@use 'bootstrap/dist/css/bootstrap' as *;
 // General theme contents
-@import 'partials/variables';
-@import 'partials/general';
-@import 'partials/generic';
-@import 'partials/mixins/function';
+@use 'partials/variables' as *;
+@use 'partials/general' as *;
+@use 'partials/generic' as *;
+@use 'partials/mixins/function' as *;
 
 // icon
-@import 'partials/font/next-icon';
-@import 'partials/font/feather';
-@import 'partials/font/fontawesome';
+@use 'partials/font/next-icon' as *;
+@use 'partials/font/feather' as *;
+@use 'partials/font/fontawesome' as *;
 
 // important Element
-@import 'partials/menu/menu-lite';
-@import 'partials/widget/widget';
+@use 'partials/menu/menu-lite' as *;
+@use 'partials/widget/widget' as *;
 
 // Theme Element
-@import 'partials/theme-elements/form';
-@import 'partials/theme-elements/radiobox-checkbox';
-@import 'partials/theme-elements/labels-badges';
-@import 'partials/theme-elements/data-tables';
-@import 'partials/theme-elements/authentication';
-@import 'partials/theme-elements/button';
-@import 'partials/theme-elements/breadcrumb-pagination';
-@import 'partials/theme-elements/progress';
-@import 'partials/theme-elements/nav';
+@use 'partials/theme-elements/form' as *;
+@use 'partials/theme-elements/radiobox-checkbox' as *;
+@use 'partials/theme-elements/labels-badges' as *;
+@use 'partials/theme-elements/data-tables' as *;
+@use 'partials/theme-elements/authentication' as *;
+@use 'partials/theme-elements/button' as *;
+@use 'partials/theme-elements/breadcrumb-pagination' as *;
+@use 'partials/theme-elements/progress' as *;
+@use 'partials/theme-elements/nav' as *;
 
 // Other
-@import 'partials/other/chat';
+@use 'partials/other/chat' as *;
 
-@import 'partials/third-party/third-party';
+@use 'partials/third-party/third-party' as *;
 
-@import 'react-dual-listbox/lib/react-dual-listbox';
+@use 'react-dual-listbox/lib/react-dual-listbox' as *;
 
 // Custom
-@import 'partials/custom';
+@use 'partials/custom' as *;

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -1,4 +1,5 @@
-@import 'assets/scss/style.scss';
+@use 'assets/scss/style' as *;
+@use 'assets/scss/partials/_variables' as *;
 
 .nav-outside.mob-backdrop {
   &.mob-fixed .pcoded-navbar {

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -62,10 +62,9 @@ export default defineConfig(({ mode }) => {
     // Configuraciones de CSS
     css: {
       preprocessorOptions: {
-        // scss: {
-        //   charset: false,
-        //   additionalData: `@import "@src/scss/styles/_variables.scss";` // Importar variables globales SCSS
-        // },
+        scss: {
+          api: "modern-compiler"
+        },
         less: {
           charset: false,
           javascriptEnabled: true


### PR DESCRIPTION
This pull request includes various changes to the SCSS files in the frontend codebase. The primary focus is on improving the use of the `sass:color` and `sass:list` modules and updating the syntax to use the `@use` rule instead of `@import`. Here are the most important changes:

### Use of `sass:color` and `sass:list` modules:

* Replaced `transparentize` with `color.adjust` for adjusting colors in multiple files, including `_general.scss`, `_menu-lite.scss`, `_chat.scss`, `_data-tables.scss`, and `_buttons.scss`. [[1]](diffhunk://#diff-bce6d569645eba3fdbd4cc7095bf4b89768dedac984e98f75214c8de12f184b9L336-R339) [[2]](diffhunk://#diff-a64290e4f5617a57f37579324d13a96c475b48fed9d3ee68f50ecf10c3ddbd96L329-R332) [[3]](diffhunk://#diff-28bc5093fc2834255a282283d5b6327797b2662859fd4e4659496163f92fe3b3L72-R74) [[4]](diffhunk://#diff-b84689aece35e1b41c39443e49f52d97787c9ca72e320f662fba19602779f790L45-R48) [[5]](diffhunk://#diff-4ddfe06be5e48c9bbd659a92e12048bafdbfb89173d51a4512f75b2053267f55L66-R72)

### Syntax updates to use `@use`:

* Changed `@import` to `@use` for importing SCSS files and modules in various files, such as `_custom.scss`, `_variables.scss`, `_generic.scss`, `_menu-lite.scss`, `_buttons.scss`, `_third-party.scss`, and `react-bootstrap.scss`. [[1]](diffhunk://#diff-3f504532fe98779ab4cbfae703b930a6f979b2f4ad403605d12326f708f54fdcR1) [[2]](diffhunk://#diff-c311946839585ed6deabeb3f23ff01a1eaaf4f0d9e9def53e1435e67b093b24bR6-R8) [[3]](diffhunk://#diff-7e0d2d2a2ff54e22a9f432c9a80bdf8d259b2a9e9b2eb055fa3f0ec731cd4a33R4-R6) [[4]](diffhunk://#diff-a64290e4f5617a57f37579324d13a96c475b48fed9d3ee68f50ecf10c3ddbd96R2-R4) [[5]](diffhunk://#diff-4ddfe06be5e48c9bbd659a92e12048bafdbfb89173d51a4512f75b2053267f55R4-R12) [[6]](diffhunk://#diff-87c1711769bc560ebcff52ff7175959154e4a309b07b42bb09d31ccad845ed7cL1-R3) [[7]](diffhunk://#diff-ff335238da26a75b6542157b6dafc71d73efd40ea7c984e09c6ad8d9e07e6f4fL1-R1)

### Updates to variable and mixin usage:

* Updated variable and mixin usage to align with the `@use` rule, ensuring variables are imported correctly from `_variables.scss` in multiple files, including `_authentication.scss`, `_breadcrumb-pagination.scss`, `_button.scss`, `_data-tables.scss`, `_labels-badges.scss`, `_nav.scss`, `_progress.scss`, and `_widget.scss`. [[1]](diffhunk://#diff-43161cdf133ba0760ab21bc0dd5dd853704ba58ee5ad1e27762e1a15b34d9f1aR4-R5) [[2]](diffhunk://#diff-01eb0d94378b59b22251b7866ec166403d4ec051a542260420ebde03dbaf2b01R5) [[3]](diffhunk://#diff-29b3c607689fe00c9bd30b8f59d74c730d2c7e0f805cf5cab7bb2535e2daf40aL1-R2) [[4]](diffhunk://#diff-b84689aece35e1b41c39443e49f52d97787c9ca72e320f662fba19602779f790R4-R6) [[5]](diffhunk://#diff-0c6b8184158a6bd3912eb5ebcbcdf4f7af1617f66837dfb9cfc7e55a705058b0R4-R5) [[6]](diffhunk://#diff-90cf4c5042a7b3e941643498938b137f729246fcef66b60ed6f3a7e1cb9a4ca0R1-R2) [[7]](diffhunk://#diff-9bbe9133ee93b3ef2d92418f7e4a70252cd6fe0d245c2d480eae91ba980410efR4-R6) [[8]](diffhunk://#diff-3c4cdd2abb87ba592098f782fb0523944189f2221e331b4a75170193700388c9R1-R2)

### Adjustments to color manipulation functions:

* Replaced `lighten` and `darken` functions with `color.adjust` for consistent color adjustments in `_variables.scss`, `_menu-lite.scss`, `_chat.scss`, and `_buttons.scss`. [[1]](diffhunk://#diff-c311946839585ed6deabeb3f23ff01a1eaaf4f0d9e9def53e1435e67b093b24bL50-R62) [[2]](diffhunk://#diff-a64290e4f5617a57f37579324d13a96c475b48fed9d3ee68f50ecf10c3ddbd96L796-R799) [[3]](diffhunk://#diff-28bc5093fc2834255a282283d5b6327797b2662859fd4e4659496163f92fe3b3L110-R112) [[4]](diffhunk://#diff-4ddfe06be5e48c9bbd659a92e12048bafdbfb89173d51a4512f75b2053267f55R4-R12)

### Indexing and list manipulation updates:

* Updated the use of `index` and `nth` functions to `list.index` and `list.nth` for better list manipulation in `_generic.scss`, `_menu-lite.scss`, `_labels-badges.scss`, and `_progress.scss`. [[1]](diffhunk://#diff-7e0d2d2a2ff54e22a9f432c9a80bdf8d259b2a9e9b2eb055fa3f0ec731cd4a33L56-R73) [[2]](diffhunk://#diff-a64290e4f5617a57f37579324d13a96c475b48fed9d3ee68f50ecf10c3ddbd96L1372-R1379) [[3]](diffhunk://#diff-0c6b8184158a6bd3912eb5ebcbcdf4f7af1617f66837dfb9cfc7e55a705058b0L12-R17) [[4]](diffhunk://#diff-9bbe9133ee93b3ef2d92418f7e4a70252cd6fe0d245c2d480eae91ba980410efL26-R33)