### PR TITLE
Use task timedelta to define days on report

### DIFF
--- a/ngen/locale/es/LC_MESSAGES/django.po
+++ b/ngen/locale/es/LC_MESSAGES/django.po
@@ -276,8 +276,8 @@ msgid "Hello %(contact_name)s"
 msgstr "Hola %(contact_name)s"
 
 #, python-format
-msgid "Here is a summary of your cases of the last %(days)s days."
-msgstr "Aquí tiene un resumen de sus casos de los últimos %(days)s días."
+msgid "Below are all your unsolved cases, along with a summary of your closed cases from the last %(days)s days."
+msgstr "A continuación se muestran todos sus casos sin resolver, junto con un resumen de sus casos cerrados de los últimos %(days)s días."
 
 msgid "Congratulation! You have <strong>0</strong> unsolved cases"
 msgstr "¡Felicidades! Tiene <strong>0</strong> casos no resueltos"

--- a/ngen/models/announcement.py
+++ b/ngen/models/announcement.py
@@ -103,7 +103,7 @@ class Communication:
         raise NotImplementedError
 
     @staticmethod
-    def communicate_contact_summary(contact, open_cases, closed_cases, tlp):
+    def communicate_contact_summary(contact, open_cases, closed_cases, tlp, days):
         """
         Weekly cases summary communication
         """
@@ -122,6 +122,7 @@ class Communication:
                     "open_cases": open_cases,
                     "closed_cases": closed_cases,
                     "tlp": tlp,
+                    "days": days,
                 },
             ),
             {

--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -145,7 +145,7 @@ def contact_summary(contacts=None, tlp=None, days=None):
                 list_open_cases,
                 list_closed_cases,
                 tlp_obj,
-                days=timedeltavalue.days,
+                days=timedeltavalue.total_seconds() / 86400,
             )
 
 

--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -113,7 +113,7 @@ def contact_summary(contacts=None, tlp=None, days=None):
         else:
             default_value = 14
             timedeltavalue = timezone.timedelta(days=default_value)
-            print(
+            logger.warning(
                 f"No interval found for the periodic task 'ngen.tasks.contact_summary'. Using default value: {default_value} days."
             )
 

--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -87,7 +87,7 @@ def case_renotification():
 
 
 @shared_task(ignore_result=True, store_errors_even_if_ignored=True)
-def contact_summary(contacts=None, tlp=None):
+def contact_summary(contacts=None, tlp=None, days=None):
     """
     Send summary of open cases to all network admins
     """
@@ -96,6 +96,26 @@ def contact_summary(contacts=None, tlp=None):
 
     tlp = tlp.lower() if tlp else config.SUMMARY_TLP.lower()
     tlp_obj = ngen.models.Tlp.objects.get(slug=tlp) if tlp and tlp != "none" else None
+
+    # Get the interval for the periodic task
+    if days is not None:
+        timedeltavalue = timezone.timedelta(days=days)
+    else:
+        task = PeriodicTask.objects.filter(task="ngen.tasks.contact_summary").first()
+        if task and task.interval:
+            interval = task.interval
+            period = interval.period  # 'seconds', 'minutes', 'hours', 'days', 'weeks'
+            every = interval.every
+
+            # Create a timedelta object based on the interval
+            timedelta_kwargs = {period: every}
+            timedeltavalue = timezone.timedelta(**timedelta_kwargs)
+        else:
+            default_value = 14
+            timedeltavalue = timezone.timedelta(days=default_value)
+            print(
+                f"No interval found for the periodic task 'ngen.tasks.contact_summary'. Using default value: {default_value} days."
+            )
 
     for contact in contacts:
         # Get all open cases for the contact
@@ -111,9 +131,9 @@ def contact_summary(contacts=None, tlp=None):
         closed_cases = ngen.models.Case.objects.filter(
             state__solved=True,
             events__network__contacts=contact,
-            solve_date__gte=timezone.now()
-            - timezone.timedelta(days=config.SUMMARY_DAYS),
+            solve_date__gte=timezone.now() - timedeltavalue,
         ).prefetch_related("events")
+
         list_closed_cases = [
             {"case": case, "events": case.events.filter(network__contacts=contact)}
             for case in closed_cases
@@ -125,6 +145,7 @@ def contact_summary(contacts=None, tlp=None):
                 list_open_cases,
                 list_closed_cases,
                 tlp_obj,
+                days=timedeltavalue.days,
             )
 
 

--- a/ngen/templates/reports/summary_contact.html
+++ b/ngen/templates/reports/summary_contact.html
@@ -3,7 +3,6 @@
 
 {% language lang %}
     {% block content_header %}
-        {% summary_days as days %}
         <div class="content">
             <h4>
                 {% blocktranslate trimmed with contact_name=contact.name %}
@@ -12,7 +11,7 @@
             </h4>
             <p>
                 {% blocktranslate trimmed %}
-                    Here is a summary of your cases of the last {{ days }} days.
+                    Below are all your unsolved cases, along with a summary of your closed cases from the last {{ days }} days.
                 {% endblocktranslate %}
             </p>
         </div>

--- a/ngen/templatetags/ngen_tags.py
+++ b/ngen/templatetags/ngen_tags.py
@@ -23,11 +23,6 @@ def mail_logo():
 
 
 @register.simple_tag
-def summary_days():
-    return config.SUMMARY_DAYS
-
-
-@register.simple_tag
 def encode_static(path, encoding="base64", file_type="image"):
     """
     a template tag that returns a encoded string representation of a staticfile

--- a/project/settings.py
+++ b/project/settings.py
@@ -465,13 +465,6 @@ CONSTANCE_CONFIG = {
         os.environ.get("SUMMARY_TLP", "red"),
         gettext_lazy("Default TLP for summary"),
     ),
-    "SUMMARY_DAYS": (
-        int(os.environ.get("SUMMARY_DAYS", 7)),
-        gettext_lazy(
-            "Default days for summary. This must be equal to the periodic task schedule created"
-        ),
-        int,
-    ),
     "TAXONOMY_ALLOW_AUTO_CREATE": (
         os.environ.get("TAXONOMY_ALLOW_AUTO_CREATE", "true").lower() in VALUES_TRUE,
         gettext_lazy(


### PR DESCRIPTION
This pull request introduces changes to improve the flexibility and functionality of the contact summary feature by allowing dynamic configuration of the summary interval (`days`) and removing hardcoded defaults. The changes span multiple files, including updates to task logic, templates, and localization strings.

### Enhancements to dynamic summary interval:
* [`ngen/tasks.py`](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387R100-R119): Updated the `contact_summary` function to dynamically determine the `days` interval for summaries. If not provided, it calculates the interval based on the periodic task's schedule or defaults to 14 days. This replaces the previously hardcoded `SUMMARY_DAYS` configuration. [[1]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387R100-R119) [[2]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387L114-R136)
* [`ngen/models/announcement.py`](diffhunk://#diff-072ff586aa68d4ad5fb8c933ff3282c5f14ad48c57fb6a24b6741767d7e6a7bfL106-R106): Modified the `communicate_contact_summary` method to accept a `days` parameter and include it in the context data for email communication. [[1]](diffhunk://#diff-072ff586aa68d4ad5fb8c933ff3282c5f14ad48c57fb6a24b6741767d7e6a7bfL106-R106) [[2]](diffhunk://#diff-072ff586aa68d4ad5fb8c933ff3282c5f14ad48c57fb6a24b6741767d7e6a7bfR125)

### Template and localization updates:
* [`ngen/templates/reports/summary_contact.html`](diffhunk://#diff-45425300c566032a07188c788c9328b6264efebdde84a193b11a70ad155c959bL6): Updated the text to reflect the new summary format, displaying both unsolved and recently closed cases. Removed the use of the `summary_days` tag. [[1]](diffhunk://#diff-45425300c566032a07188c788c9328b6264efebdde84a193b11a70ad155c959bL6) [[2]](diffhunk://#diff-45425300c566032a07188c788c9328b6264efebdde84a193b11a70ad155c959bL15-R14)
* [`ngen/locale/es/LC_MESSAGES/django.po`](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L279-R280): Updated the Spanish translation for the new summary message format.

### Removal of deprecated configuration:
* [`project/settings.py`](diffhunk://#diff-25e4824b66759633b73f6971463e7d0f84a3f8563d999460250b9a7db52098bcL468-L474): Removed the `SUMMARY_DAYS` configuration setting, as its functionality has been replaced by the dynamic interval logic.
* [`ngen/templatetags/ngen_tags.py`](diffhunk://#diff-712306d210e24beabfb1a9af47990fe4a25347db797b538f73b3dc4d0af1653dL25-L29): Removed the `summary_days` template tag, which is no longer needed.