### PR TITLE
Use task timedelta to define days on report (#225)

### DIFF
--- a/ngen/locale/es/LC_MESSAGES/django.po
+++ b/ngen/locale/es/LC_MESSAGES/django.po
@@ -276,8 +276,8 @@ msgid "Hello %(contact_name)s"
 msgstr "Hola %(contact_name)s"
 
 #, python-format
-msgid "Here is a summary of your cases of the last %(days)s days."
-msgstr "Aquí tiene un resumen de sus casos de los últimos %(days)s días."
+msgid "Below are all your unsolved cases, along with a summary of your closed cases from the last %(days)s days."
+msgstr "A continuación se muestran todos sus casos sin resolver, junto con un resumen de sus casos cerrados de los últimos %(days)s días."
 
 msgid "Congratulation! You have <strong>0</strong> unsolved cases"
 msgstr "¡Felicidades! Tiene <strong>0</strong> casos no resueltos"

--- a/ngen/models/announcement.py
+++ b/ngen/models/announcement.py
@@ -103,7 +103,7 @@ class Communication:
         raise NotImplementedError
 
     @staticmethod
-    def communicate_contact_summary(contact, open_cases, closed_cases, tlp):
+    def communicate_contact_summary(contact, open_cases, closed_cases, tlp, days):
         """
         Weekly cases summary communication
         """
@@ -122,6 +122,7 @@ class Communication:
                     "open_cases": open_cases,
                     "closed_cases": closed_cases,
                     "tlp": tlp,
+                    "days": days,
                 },
             ),
             {

--- a/ngen/templates/reports/summary_contact.html
+++ b/ngen/templates/reports/summary_contact.html
@@ -3,7 +3,6 @@
 
 {% language lang %}
     {% block content_header %}
-        {% summary_days as days %}
         <div class="content">
             <h4>
                 {% blocktranslate trimmed with contact_name=contact.name %}
@@ -12,7 +11,7 @@
             </h4>
             <p>
                 {% blocktranslate trimmed %}
-                    Here is a summary of your cases of the last {{ days }} days.
+                    Below are all your unsolved cases, along with a summary of your closed cases from the last {{ days }} days.
                 {% endblocktranslate %}
             </p>
         </div>

--- a/ngen/templatetags/ngen_tags.py
+++ b/ngen/templatetags/ngen_tags.py
@@ -23,11 +23,6 @@ def mail_logo():
 
 
 @register.simple_tag
-def summary_days():
-    return config.SUMMARY_DAYS
-
-
-@register.simple_tag
 def encode_static(path, encoding="base64", file_type="image"):
     """
     a template tag that returns a encoded string representation of a staticfile

--- a/project/settings.py
+++ b/project/settings.py
@@ -465,13 +465,6 @@ CONSTANCE_CONFIG = {
         os.environ.get("SUMMARY_TLP", "red"),
         gettext_lazy("Default TLP for summary"),
     ),
-    "SUMMARY_DAYS": (
-        int(os.environ.get("SUMMARY_DAYS", 7)),
-        gettext_lazy(
-            "Default days for summary. This must be equal to the periodic task schedule created"
-        ),
-        int,
-    ),
     "TAXONOMY_ALLOW_AUTO_CREATE": (
         os.environ.get("TAXONOMY_ALLOW_AUTO_CREATE", "true").lower() in VALUES_TRUE,
         gettext_lazy(


### PR DESCRIPTION
Going to v2.3.11

Commits:

* Use task timedelta to define days on report

* Update ngen/tasks.py

* Update ngen/tasks.py

