### PR TITLE
Feature/Add default value recommendation for install script

### DIFF
--- a/docker/.env/ngen.prod.env.example
+++ b/docker/.env/ngen.prod.env.example
@@ -24,7 +24,7 @@ DJANGO_ALLOWED_HOSTS=*
 # Example:
 # DJANGO_CORS_ALLOWED_ORIGINS=https://ngen.yourdomain.com
 
-DJANGO_CORS_ALLOWED_ORIGINS=
+DJANGO_CORS_ALLOWED_ORIGINS=https://127.0.0.1,https://localhost
 
 #### Email
 


### PR DESCRIPTION
If DJANGO_CORS_ALLOWED_ORIGINS is left empty during the installation, it will cause runtime errors in services like postgres and celery.
This commit defines a safe default (https://127.0.0.1,https://localhost) in ngen.prod.env.example which improves the setup script’s interactive prompt to prevent users from leaving it blank during installation.