### PR TITLE
Fix event and network modifications on network edit

### DIFF
--- a/ngen/models/common/mixins.py
+++ b/ngen/models/common/mixins.py
@@ -116,9 +116,10 @@ class TreeModelMixin(AL_Node, ValidationModelMixin):
 
     def clean_fields(self, exclude=None):
         # Check loops. This is not really performant, but it works
+        visited = set()
         elem = self.parent
         while elem:
-            if elem.pk == self.pk:
+            if elem.pk == self.pk or elem.pk in visited:
                 raise ValidationError(
                     {
                         "parent": [
@@ -128,6 +129,7 @@ class TreeModelMixin(AL_Node, ValidationModelMixin):
                         ]
                     }
                 )
+            visited.add(elem.pk)
             elem = elem.parent
         super().clean_fields(exclude=exclude)
 

--- a/ngen/tests/models/test_constituency.py
+++ b/ngen/tests/models/test_constituency.py
@@ -1,13 +1,43 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from ngen.models import Network, NetworkEntity
+from ngen.models import (
+    Network,
+    NetworkEntity,
+    Event,
+    Taxonomy,
+    Feed,
+    Tlp,
+    Priority,
+    User,
+)
 
 
 class ConstituencyTest(TestCase):
 
+    fixtures = [
+        "tests/priority.json",
+    ]
+
     @classmethod
     def setUpTestData(cls):
+        cls.taxonomy = Taxonomy.objects.create(
+            type="incident", name="Phising", slug="phising"
+        )
+        cls.feed = Feed.objects.create(slug="shodan", name="Shodan")
+        cls.tlp = Tlp.objects.create(
+            slug="clear",
+            when="Given some circumstance",
+            why="Some reason",
+            information="Some information",
+            description="Some description",
+            name="Clear",
+            code=0,
+        )
+        cls.priority = Priority.objects.get(name="Medium", severity=3)
+        cls.user = User.objects.create(
+            username="test", password="test", priority=cls.priority
+        )
         cls.example_entity = NetworkEntity.objects.create(name="Example Entity")
         cls.default_ipv4 = Network.objects.create(cidr="0.0.0.0/0")
         cls.default_ipv6 = Network.objects.create(cidr="::/0")
@@ -221,6 +251,75 @@ class ConstituencyTest(TestCase):
             id=self.example_entity.id,
         )
 
+    def test_delete_ipv4_network_with_events_and_children(self):
+        test1 = Network.objects.create(cidr="163.10.0.0/20")
+
+        event1 = Event.objects.create(
+            cidr="163.10.4.111/32",
+            taxonomy=self.taxonomy,
+            feed=self.feed,
+            tlp=self.tlp,
+            reporter=self.user,
+            notes="Some notes 1",
+            priority=self.priority,
+        )
+
+        event2 = Event.objects.create(
+            cidr="163.10.4.112/32",
+            taxonomy=self.taxonomy,
+            feed=self.feed,
+            tlp=self.tlp,
+            reporter=self.user,
+            notes="Some notes 2",
+            priority=self.priority,
+        )
+
+        event3 = Event.objects.create(
+            cidr="163.10.1.1/32",
+            taxonomy=self.taxonomy,
+            feed=self.feed,
+            tlp=self.tlp,
+            reporter=self.user,
+            notes="Some notes 3",
+            priority=self.priority,
+        )
+
+        event4 = Event.objects.create(
+            cidr="163.10.128.1/32",
+            taxonomy=self.taxonomy,
+            feed=self.feed,
+            tlp=self.tlp,
+            reporter=self.user,
+            notes="Some notes 4",
+            priority=self.priority,
+        )
+
+        event5 = Event.objects.create(
+            cidr="163.10.2.111/32",
+            taxonomy=self.taxonomy,
+            feed=self.feed,
+            tlp=self.tlp,
+            reporter=self.user,
+            notes="Some notes 4",
+            priority=self.priority,
+        )
+
+        self.assertIn(test1, Network.objects.all())
+        self.assertIn(event1, test1.events.all())
+        self.assertIn(event2, test1.events.all())
+        self.assertIn(event3, self.ipv4_1_1.events.all())
+        self.assertIn(event4, self.ipv4_1.events.all())
+        self.assertIn(event5, self.ipv4_1_2.events.all())
+
+        test1.delete()
+
+        self.assertNotIn(test1, Network.objects.all())
+        self.assertIn(event3, self.ipv4_1_1.events.all())
+        self.assertIn(event4, self.ipv4_1.events.all())
+        self.assertIn(event1, self.ipv4_1.events.all())
+        self.assertIn(event2, self.ipv4_1.events.all())
+        self.assertIn(event5, self.ipv4_1_2.events.all())
+
     def test_insert_ipv4_network(self):
         test1 = Network.objects.create(cidr="163.10.0.0/20")
         self.ipv4_1_1.refresh_from_db()
@@ -245,3 +344,797 @@ class ConstituencyTest(TestCase):
         )
         self.assertEqual(test1, self.ipv4_1_1.parent)
         self.assertEqual(test1, self.ipv4_1_2.parent)
+
+    def _create_networks(self):
+        """
+        redes       (eventos)
+        1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32)
+            1.1.0.0/16  (1.1.0.1/32, 1.1.0.2/32, 1.1.192.1/32, 1.1.129.1/32)
+                1.1.1.0/24  (1.1.1.1/32, 1.1.1.2/32, 1.1.1.129/32)
+                1.1.2.0/24  (1.1.2.1/32, 1.1.2.2/32, 1.1.2.129/32)
+                1.1.3.0/24  (1.1.3.1/32, 1.1.3.2/32, 1.1.3.129/32)
+                1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32)
+            1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32, 1.2.129.1/32)
+                1.2.1.0/24  (1.2.1.1/32, 1.2.1.2/32, 1.2.1.129/32)
+                1.2.2.0/24  (1.2.2.1/32, 1.2.2.2/32, 1.2.2.129/32)
+                1.2.3.0/24  (1.2.3.1/32, 1.2.3.2/32, 1.2.3.129/32)
+                1.2.128.0/24  (1.2.128.1/32, 1.2.128.2/32, 1.2.128.129/32)
+            1.3.0.0/16  (1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32)
+                1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32)
+                1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32)
+                1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32)
+                1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32)
+            1.32.0.0/16  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32)
+        """
+        # Init networks and events
+        self.networks = {
+            "1.0.0.0/8": None,
+            "1.1.0.0/16": None,
+            "1.1.1.0/24": None,
+            "1.1.2.0/24": None,
+            "1.1.3.0/24": None,
+            "1.1.128.0/24": None,
+            "1.2.0.0/16": None,
+            "1.2.1.0/24": None,
+            "1.2.2.0/24": None,
+            "1.2.3.0/24": None,
+            "1.2.128.0/24": None,
+            "1.3.0.0/16": None,
+            "1.3.1.0/24": None,
+            "1.3.2.0/24": None,
+            "1.3.3.0/24": None,
+            "1.3.128.0/24": None,
+            "1.32.0.0/16": None,
+        }
+        self.events = {
+            "1.0.0.1/32": None,
+            "1.0.0.2/32": None,
+            "1.33.0.1/32": None,
+            "1.33.0.2/32": None,
+            "1.128.0.1/32": None,
+            "1.129.0.1/32": None,
+            "1.1.0.1/32": None,
+            "1.1.0.2/32": None,
+            "1.1.192.1/32": None,
+            "1.1.129.1/32": None,
+            "1.1.1.1/32": None,
+            "1.1.1.2/32": None,
+            "1.1.1.129/32": None,
+            "1.1.2.1/32": None,
+            "1.1.2.2/32": None,
+            "1.1.2.129/32": None,
+            "1.1.3.1/32": None,
+            "1.1.3.2/32": None,
+            "1.1.3.129/32": None,
+            "1.1.128.1/32": None,
+            "1.1.128.2/32": None,
+            "1.1.128.129/32": None,
+            "1.2.0.1/32": None,
+            "1.2.0.2/32": None,
+            "1.2.192.1/32": None,
+            "1.2.129.1/32": None,
+            "1.2.1.1/32": None,
+            "1.2.1.2/32": None,
+            "1.2.1.129/32": None,
+            "1.2.2.1/32": None,
+            "1.2.2.2/32": None,
+            "1.2.2.129/32": None,
+            "1.2.3.1/32": None,
+            "1.2.3.2/32": None,
+            "1.2.3.129/32": None,
+            "1.2.128.1/32": None,
+            "1.2.128.2/32": None,
+            "1.2.128.129/32": None,
+            "1.3.0.1/32": None,
+            "1.3.0.2/32": None,
+            "1.3.192.1/32": None,
+            "1.3.129.1/32": None,
+            "1.3.1.1/32": None,
+            "1.3.1.2/32": None,
+            "1.3.1.129/32": None,
+            "1.3.2.1/32": None,
+            "1.3.2.2/32": None,
+            "1.3.2.129/32": None,
+            "1.3.3.1/32": None,
+            "1.3.3.2/32": None,
+            "1.3.3.129/32": None,
+            "1.3.128.1/32": None,
+            "1.3.128.2/32": None,
+            "1.3.128.129/32": None,
+            "1.32.0.1/32": None,
+            "1.32.0.2/32": None,
+            "1.32.192.1/32": None,
+            "1.32.129.1/32": None,
+        }
+        # delete if exists
+        Network.objects.filter(cidr__in=self.networks.keys()).delete()
+        Event.objects.filter(cidr__in=self.events.keys()).delete()
+        # create new
+        for key in self.networks.keys():
+            self.networks[key] = Network.objects.create(cidr=key)
+        for key in self.events.keys():
+            self.events[key] = Event.objects.create(
+                cidr=key,
+                taxonomy=self.taxonomy,
+                feed=self.feed,
+                tlp=self.tlp,
+                reporter=self.user,
+                notes="Some notes " + key,
+                priority=self.priority,
+            )
+        # networks
+        # 1.0.0.0/8
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].get_children().all()),
+            {
+                self.networks["1.1.0.0/16"],
+                self.networks["1.2.0.0/16"],
+                self.networks["1.3.0.0/16"],
+                self.networks["1.32.0.0/16"],
+            },
+        )
+        # 1.1.0.0/16
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].get_children().all()),
+            {
+                self.networks["1.3.1.0/24"],
+                self.networks["1.3.2.0/24"],
+                self.networks["1.3.3.0/24"],
+                self.networks["1.3.128.0/24"],
+            },
+        )
+        # 1.2.0.0/16
+        self.assertSetEqual(
+            set(self.networks["1.2.0.0/16"].get_children().all()),
+            {
+                self.networks["1.2.1.0/24"],
+                self.networks["1.2.2.0/24"],
+                self.networks["1.2.3.0/24"],
+                self.networks["1.2.128.0/24"],
+            },
+        )
+        # 1.3.0.0/16
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].get_children().all()),
+            {
+                self.networks["1.3.1.0/24"],
+                self.networks["1.3.2.0/24"],
+                self.networks["1.3.3.0/24"],
+                self.networks["1.3.128.0/24"],
+            },
+        )
+
+        # events
+        # 1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32)
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].events.all()),
+            {
+                self.events["1.0.0.1/32"],
+                self.events["1.0.0.2/32"],
+                self.events["1.33.0.1/32"],
+                self.events["1.33.0.2/32"],
+                self.events["1.128.0.1/32"],
+                self.events["1.129.0.1/32"],
+            },
+        )
+        # 1.1.0.0/16  (1.1.0.1/32, 1.1.0.2/32, 1.1.192.1/32, 1.1.129.1/32)
+        self.assertSetEqual(
+            set(self.networks["1.1.0.0/16"].events.all()),
+            {
+                self.events["1.1.0.1/32"],
+                self.events["1.1.0.2/32"],
+                self.events["1.1.192.1/32"],
+                self.events["1.1.129.1/32"],
+            },
+        )
+        # 1.1.1.0/24  (1.1.1.1/32, 1.1.1.2/32, 1.1.1.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.1.1.0/24"].events.all()),
+            {
+                self.events["1.1.1.1/32"],
+                self.events["1.1.1.2/32"],
+                self.events["1.1.1.129/32"],
+            },
+        )
+        # 1.1.2.0/24  (1.1.2.1/32, 1.1.2.2/32, 1.1.2.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.1.2.0/24"].events.all()),
+            {
+                self.events["1.1.2.1/32"],
+                self.events["1.1.2.2/32"],
+                self.events["1.1.2.129/32"],
+            },
+        )
+        # 1.1.3.0/24  (1.1.3.1/32, 1.1.3.2/32, 1.1.3.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.1.3.0/24"].events.all()),
+            {
+                self.events["1.1.3.1/32"],
+                self.events["1.1.3.2/32"],
+                self.events["1.1.3.129/32"],
+            },
+        )
+        # 1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.1.128.0/24"].events.all()),
+            {
+                self.events["1.1.128.1/32"],
+                self.events["1.1.128.2/32"],
+                self.events["1.1.128.129/32"],
+            },
+        )
+        # 1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32, 1.2.129.1/32)
+        self.assertSetEqual(
+            set(self.networks["1.2.0.0/16"].events.all()),
+            {
+                self.events["1.2.0.1/32"],
+                self.events["1.2.0.2/32"],
+                self.events["1.2.192.1/32"],
+                self.events["1.2.129.1/32"],
+            },
+        )
+        # 1.2.1.0/24  (1.2.1.1/32, 1.2.1.2/32, 1.2.1.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.2.1.0/24"].events.all()),
+            {
+                self.events["1.2.1.1/32"],
+                self.events["1.2.1.2/32"],
+                self.events["1.2.1.129/32"],
+            },
+        )
+        # 1.2.2.0/24  (1.2.2.1/32, 1.2.2.2/32, 1.2.2.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.2.2.0/24"].events.all()),
+            {
+                self.events["1.2.2.1/32"],
+                self.events["1.2.2.2/32"],
+                self.events["1.2.2.129/32"],
+            },
+        )
+        # 1.2.3.0/24  (1.2.3.1/32, 1.2.3.2/32, 1.2.3.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.2.3.0/24"].events.all()),
+            {
+                self.events["1.2.3.1/32"],
+                self.events["1.2.3.2/32"],
+                self.events["1.2.3.129/32"],
+            },
+        )
+        # 1.2.128.0/24  (1.2.128.1/32, 1.2.128.2/32, 1.2.128.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.2.128.0/24"].events.all()),
+            {
+                self.events["1.2.128.1/32"],
+                self.events["1.2.128.2/32"],
+                self.events["1.2.128.129/32"],
+            },
+        )
+        # 1.3.0.0/16  (1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32)
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].events.all()),
+            {
+                self.events["1.3.0.1/32"],
+                self.events["1.3.0.2/32"],
+                self.events["1.3.192.1/32"],
+                self.events["1.3.129.1/32"],
+            },
+        )
+        # 1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.3.1.0/24"].events.all()),
+            {
+                self.events["1.3.1.1/32"],
+                self.events["1.3.1.2/32"],
+                self.events["1.3.1.129/32"],
+            },
+        )
+        # 1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.3.2.0/24"].events.all()),
+            {
+                self.events["1.3.2.1/32"],
+                self.events["1.3.2.2/32"],
+                self.events["1.3.2.129/32"],
+            },
+        )
+        # 1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.3.3.0/24"].events.all()),
+            {
+                self.events["1.3.3.1/32"],
+                self.events["1.3.3.2/32"],
+                self.events["1.3.3.129/32"],
+            },
+        )
+        # 1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32)
+        self.assertSetEqual(
+            set(self.networks["1.3.128.0/24"].events.all()),
+            {
+                self.events["1.3.128.1/32"],
+                self.events["1.3.128.2/32"],
+                self.events["1.3.128.129/32"],
+            },
+        )
+        # 1.32.0.0/16  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32)
+        self.assertSetEqual(
+            set(self.networks["1.32.0.0/16"].events.all()),
+            {
+                self.events["1.32.0.1/32"],
+                self.events["1.32.0.2/32"],
+                self.events["1.32.192.1/32"],
+                self.events["1.32.129.1/32"],
+            },
+        )
+
+    def test_modify_network_increase_mask(self):
+        """
+        modificar la red - aumentar mascara a red no existente
+        1.3.0.0/16 -> 1.3.0.0/17
+        expectativa:
+        redes       (eventos)
+        1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+            1.1.0.0/16  (1.1.0.1/32, 1.1.0.2/32, 1.1.192.1/32)
+                1.1.1.0/24  (1.1.1.1/32, 1.1.1.2/32, 1.1.1.129/32)
+                1.1.2.0/24  (1.1.2.1/32, 1.1.2.2/32, 1.1.2.129/32)
+                1.1.3.0/24  (1.1.3.1/32, 1.1.3.2/32, 1.1.3.129/32)
+                1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32)
+            1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32)
+                1.2.1.0/24  (1.2.1.1/32, 1.2.1.2/32, 1.2.1.129/32)
+                1.2.2.0/24  (1.2.2.1/32, 1.2.2.2/32, 1.2.2.129/32)
+                1.2.3.0/24  (1.2.3.1/32, 1.2.3.2/32, 1.2.3.129/32)
+                1.2.128.0/24  (1.2.128.1/32, 1.2.128.2/32, 1.2.128.129/32)
+            1.3.0.0/17  (1.3.0.1/32, 1.3.0.2/32) <<-
+                1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32)
+                1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32)
+                1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32)
+            1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32) <<-
+            1.32.0.0/16  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32)
+        """
+        self._create_networks()
+
+        self.networks["1.3.0.0/16"].cidr = "1.3.0.0/17"
+        self.networks["1.3.0.0/16"].save()
+
+        for n in self.networks.values():
+            n.refresh_from_db()
+        for e in self.events.values():
+            e.refresh_from_db()
+
+        # networks
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].get_children().all()),
+            {
+                self.networks["1.3.1.0/24"],
+                self.networks["1.3.2.0/24"],
+                self.networks["1.3.3.0/24"],
+            },
+        )
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].get_children().all()),
+            {
+                self.networks["1.1.0.0/16"],
+                self.networks["1.2.0.0/16"],
+                self.networks["1.3.0.0/16"],
+                self.networks["1.3.128.0/24"],
+                self.networks["1.32.0.0/16"],
+            },
+        )
+        self.assertIn(
+            self.networks["1.3.128.0/24"],
+            self.networks["1.0.0.0/8"].get_children().all(),
+        )
+
+        # events
+        # 1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].events.all()),
+            {
+                self.events["1.0.0.1/32"],
+                self.events["1.0.0.2/32"],
+                self.events["1.33.0.1/32"],
+                self.events["1.33.0.2/32"],
+                self.events["1.128.0.1/32"],
+                self.events["1.129.0.1/32"],
+                self.events["1.3.192.1/32"],
+                self.events["1.3.129.1/32"],
+            },
+        )
+        # 1.3.0.0/17  (1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].events.all()),
+            {
+                self.events["1.3.0.1/32"],
+                self.events["1.3.0.2/32"],
+            },
+        )
+        # 1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.128.0/24"].events.all()),
+            {
+                self.events["1.3.128.1/32"],
+                self.events["1.3.128.2/32"],
+                self.events["1.3.128.129/32"],
+            },
+        )
+
+    def test_modify_network_decrease_mask(self):
+        """
+        modificar la red - disminuir mascara a red no existente
+        1.3.0.0/16 -> 1.2.0.0/15
+        redes       (eventos)
+        1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32)
+            1.1.0.0/16  (1.1.0.1/32, 1.1.0.2/32, 1.1.192.1/32, 1.1.129.1/32)
+                1.1.1.0/24  (1.1.1.1/32, 1.1.1.2/32, 1.1.1.129/32)
+                1.1.2.0/24  (1.1.2.1/32, 1.1.2.2/32, 1.1.2.129/32)
+                1.1.3.0/24  (1.1.3.1/32, 1.1.3.2/32, 1.1.3.129/32)
+                1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32)
+            1.2.0.0/15  (1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+                1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32, 1.2.129.1/32) <<-
+                    1.2.1.0/24  (1.2.1.1/32, 1.2.1.2/32, 1.2.1.129/32) <<-
+                    1.2.2.0/24  (1.2.2.1/32, 1.2.2.2/32, 1.2.2.129/32) <<-
+                    1.2.3.0/24  (1.2.3.1/32, 1.2.3.2/32, 1.2.3.129/32) <<-
+                    1.2.128.0/24  (1.2.128.1/32, 1.2.128.2/32, 1.2.128.129/32) <<-
+                1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32) <<-
+                1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32) <<-
+                1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32) <<-
+                1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32) <<-
+            1.32.0.0/16  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32)
+        """
+        self._create_networks()
+        self.networks["1.3.0.0/16"].cidr = "1.2.0.0/15"
+        self.networks["1.3.0.0/16"].save()
+
+        for n in self.networks.values():
+            n.refresh_from_db()
+        for e in self.events.values():
+            e.refresh_from_db()
+
+        # networks
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].get_children().all()),
+            {
+                self.networks["1.1.0.0/16"],
+                self.networks["1.3.0.0/16"],
+                self.networks["1.32.0.0/16"],
+            },
+        )
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].get_children().all()),
+            {
+                self.networks["1.2.0.0/16"],
+                self.networks["1.3.1.0/24"],
+                self.networks["1.3.2.0/24"],
+                self.networks["1.3.3.0/24"],
+                self.networks["1.3.128.0/24"],
+            },
+        )
+        self.assertSetEqual(
+            set(self.networks["1.2.0.0/16"].get_children().all()),
+            {
+                self.networks["1.2.1.0/24"],
+                self.networks["1.2.2.0/24"],
+                self.networks["1.2.3.0/24"],
+                self.networks["1.2.128.0/24"],
+            },
+        )
+
+        # events
+        # 1.2.0.0/15  (1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].events.all()),
+            {
+                self.events["1.3.0.1/32"],
+                self.events["1.3.0.2/32"],
+                self.events["1.3.192.1/32"],
+                self.events["1.3.129.1/32"],
+            },
+        )
+        # 1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32, 1.2.129.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.2.0.0/16"].events.all()),
+            {
+                self.events["1.2.0.1/32"],
+                self.events["1.2.0.2/32"],
+                self.events["1.2.192.1/32"],
+                self.events["1.2.129.1/32"],
+            },
+        )
+        # 1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.1.0/24"].events.all()),
+            {
+                self.events["1.3.1.1/32"],
+                self.events["1.3.1.2/32"],
+                self.events["1.3.1.129/32"],
+            },
+        )
+
+        # 1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.2.0/24"].events.all()),
+            {
+                self.events["1.3.2.1/32"],
+                self.events["1.3.2.2/32"],
+                self.events["1.3.2.129/32"],
+            },
+        )
+
+        # 1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.3.0/24"].events.all()),
+            {
+                self.events["1.3.3.1/32"],
+                self.events["1.3.3.2/32"],
+                self.events["1.3.3.129/32"],
+            },
+        )
+
+        # 1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.128.0/24"].events.all()),
+            {
+                self.events["1.3.128.1/32"],
+                self.events["1.3.128.2/32"],
+                self.events["1.3.128.129/32"],
+            },
+        )
+
+    def test_modify_network_change_tree(self):
+        """
+        modificar la red - cambiar de arbol
+        1.3.0.0/16 -> 1.1.128.0/17
+        redes       (eventos)
+        1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32, 1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+            1.1.0.0/16  (1.1.0.1/32, 1.1.0.2/32)
+                1.1.1.0/24  (1.1.1.1/32, 1.1.1.2/32, 1.1.1.129/32)
+                1.1.2.0/24  (1.1.2.1/32, 1.1.2.2/32, 1.1.2.129/32)
+                1.1.3.0/24  (1.1.3.1/32, 1.1.3.2/32, 1.1.3.129/32)
+                1.1.128.0/17 (1.1.192.1/32, 1.1.129.1/32) <<-
+                    1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32) <<-
+            1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32, 1.2.129.1/32)
+                1.2.1.0/24  (1.2.1.1/32, 1.2.1.2/32, 1.2.1.129/32)
+                1.2.2.0/24  (1.2.2.1/32, 1.2.2.2/32, 1.2.2.129/32)
+                1.2.3.0/24  (1.2.3.1/32, 1.2.3.2/32, 1.2.3.129/32)
+                1.2.128.0/24  (1.2.128.1/32, 1.2.128.2/32, 1.2.128.129/32)
+            1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32)
+            1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32)
+            1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32)
+            1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32)
+            1.32.0.0/16  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32)
+        """
+        self._create_networks()
+
+        self.networks["1.3.0.0/16"].cidr = "1.1.128.0/17"
+        self.networks["1.3.0.0/16"].save()
+
+        for n in self.networks.values():
+            n.refresh_from_db()
+        for e in self.events.values():
+            e.refresh_from_db()
+
+        # networks
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].get_children().all()),
+            {
+                self.networks["1.1.0.0/16"],
+                self.networks["1.2.0.0/16"],
+                self.networks["1.3.1.0/24"],
+                self.networks["1.3.2.0/24"],
+                self.networks["1.3.3.0/24"],
+                self.networks["1.3.128.0/24"],
+                self.networks["1.32.0.0/16"],
+            },
+        )
+        self.assertSetEqual(
+            set(self.networks["1.1.0.0/16"].get_children().all()),
+            {
+                self.networks["1.1.1.0/24"],
+                self.networks["1.1.2.0/24"],
+                self.networks["1.1.3.0/24"],
+                self.networks["1.3.0.0/16"],
+            },
+        )
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].get_children().all()),
+            {
+                self.networks["1.1.128.0/24"],
+            },
+        )
+
+        # events
+        # 1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32, 1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].events.all()),
+            {
+                self.events["1.0.0.1/32"],
+                self.events["1.0.0.2/32"],
+                self.events["1.33.0.1/32"],
+                self.events["1.33.0.2/32"],
+                self.events["1.128.0.1/32"],
+                self.events["1.129.0.1/32"],
+                self.events["1.3.0.1/32"],
+                self.events["1.3.0.2/32"],
+                self.events["1.3.192.1/32"],
+                self.events["1.3.129.1/32"],
+            },
+        )
+        # 1.1.128.0/17 (1.1.192.1/32, 1.1.129.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].events.all()),
+            {
+                self.events["1.1.192.1/32"],
+                self.events["1.1.129.1/32"],
+            },
+        )
+        # 1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.1.128.0/24"].events.all()),
+            {
+                self.events["1.1.128.1/32"],
+                self.events["1.1.128.2/32"],
+                self.events["1.1.128.129/32"],
+            },
+        )
+
+    def test_modify_network_make_leaf(self):
+        """
+        modificar la red - hacer hoja
+        1.3.0.0/16 -> 1.3.0.44/32
+        redes       (eventos)
+        1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32, 1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+            1.1.0.0/16  (1.1.0.1/32, 1.1.0.2/32, 1.1.192.1/32, 1.1.129.1/32)
+                1.1.1.0/24  (1.1.1.1/32, 1.1.1.2/32, 1.1.1.129/32)
+                1.1.2.0/24  (1.1.2.1/32, 1.1.2.2/32, 1.1.2.129/32)
+                1.1.3.0/24  (1.1.3.1/32, 1.1.3.2/32, 1.1.3.129/32)
+                1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32)
+            1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32, 1.2.129.1/32)
+                1.2.1.0/24  (1.2.1.1/32, 1.2.1.2/32, 1.2.1.129/32)
+                1.2.2.0/24  (1.2.2.1/32, 1.2.2.2/32, 1.2.2.129/32)
+                1.2.3.0/24  (1.2.3.1/32, 1.2.3.2/32, 1.2.3.129/32)
+                1.2.128.0/24  (1.2.128.1/32, 1.2.128.2/32, 1.2.128.129/32)
+            1.3.0.44/16  () <<-
+            1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32)
+            1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32)
+            1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32)
+            1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32)
+            1.32.0.0/16  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32)
+        """
+        self._create_networks()
+
+        self.networks["1.3.0.0/16"].cidr = "1.3.0.44/32"
+        self.networks["1.3.0.0/16"].save()
+
+        for n in self.networks.values():
+            n.refresh_from_db()
+        for e in self.events.values():
+            e.refresh_from_db()
+
+        # networks
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].get_children().all()),
+            {
+                self.networks["1.1.0.0/16"],
+                self.networks["1.2.0.0/16"],
+                self.networks["1.3.0.0/16"],
+                self.networks["1.32.0.0/16"],
+                self.networks["1.3.1.0/24"],
+                self.networks["1.3.2.0/24"],
+                self.networks["1.3.3.0/24"],
+                self.networks["1.3.128.0/24"],
+            },
+        )
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].get_children().all()),
+            set(),
+        )
+
+        # events
+        # 1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.33.0.1/32, 1.33.0.2/32, 1.128.0.1/32, 1.129.0.1/32, 1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].events.all()),
+            {
+                self.events["1.0.0.1/32"],
+                self.events["1.0.0.2/32"],
+                self.events["1.33.0.1/32"],
+                self.events["1.33.0.2/32"],
+                self.events["1.128.0.1/32"],
+                self.events["1.129.0.1/32"],
+                self.events["1.3.0.1/32"],
+                self.events["1.3.0.2/32"],
+                self.events["1.3.192.1/32"],
+                self.events["1.3.129.1/32"],
+            },
+        )
+        # 1.3.0.44/16  () <<-
+        self.assertSetEqual(
+            set(self.networks["1.3.0.0/16"].events.all()),
+            set(),
+        )
+
+    def test_modify_win_parent_events(self):
+        """
+        modificar la red - hacer ganar eventos del padre sin cambiar arbol de redes
+        1.32.0.0/16 -> 1.32.0.0/15
+        redes       (eventos)
+        1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.128.0.1/32, 1.129.0.1/32) <<-
+            1.1.0.0/16  (1.1.0.1/32, 1.1.0.2/32, 1.1.192.1/32, 1.1.129.1/32)
+                1.1.1.0/24  (1.1.1.1/32, 1.1.1.2/32, 1.1.1.129/32)
+                1.1.2.0/24  (1.1.2.1/32, 1.1.2.2/32, 1.1.2.129/32)
+                1.1.3.0/24  (1.1.3.1/32, 1.1.3.2/32, 1.1.3.129/32)
+                1.1.128.0/24  (1.1.128.1/32, 1.1.128.2/32, 1.1.128.129/32)
+            1.2.0.0/16  (1.2.0.1/32, 1.2.0.2/32, 1.2.192.1/32, 1.2.129.1/32)
+                1.2.1.0/24  (1.2.1.1/32, 1.2.1.2/32, 1.2.1.129/32)
+                1.2.2.0/24  (1.2.2.1/32, 1.2.2.2/32, 1.2.2.129/32)
+                1.2.3.0/24  (1.2.3.1/32, 1.2.3.2/32, 1.2.3.129/32)
+                1.2.128.0/24  (1.2.128.1/32, 1.2.128.2/32, 1.2.128.129/32)
+            1.3.0.0/16  (1.3.0.1/32, 1.3.0.2/32, 1.3.192.1/32, 1.3.129.1/32)
+                1.3.1.0/24  (1.3.1.1/32, 1.3.1.2/32, 1.3.1.129/32)
+                1.3.2.0/24  (1.3.2.1/32, 1.3.2.2/32, 1.3.2.129/32)
+                1.3.3.0/24  (1.3.3.1/32, 1.3.3.2/32, 1.3.3.129/32)
+                1.3.128.0/24  (1.3.128.1/32, 1.3.128.2/32, 1.3.128.129/32)
+            1.32.0.0/15  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32, 1.33.0.1/32, 1.33.0.2/32) <<-
+        """
+        self._create_networks()
+
+        self.networks["1.32.0.0/16"].cidr = "1.32.0.0/15"
+        self.networks["1.32.0.0/16"].save()
+
+        for n in self.networks.values():
+            n.refresh_from_db()
+        for e in self.events.values():
+            e.refresh_from_db()
+
+        # networks
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].get_children().all()),
+            {
+                self.networks["1.1.0.0/16"],
+                self.networks["1.2.0.0/16"],
+                self.networks["1.3.0.0/16"],
+                self.networks["1.32.0.0/16"],
+            },
+        )
+        self.assertSetEqual(
+            set(self.networks["1.32.0.0/16"].get_children().all()),
+            set(),
+        )
+
+        # events
+        # 1.0.0.0/8   (1.0.0.1/32, 1.0.0.2/32, 1.128.0.1/32, 1.129.0.1/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.0.0.0/8"].events.all()),
+            {
+                self.events["1.0.0.1/32"],
+                self.events["1.0.0.2/32"],
+                self.events["1.128.0.1/32"],
+                self.events["1.129.0.1/32"],
+            },
+        )
+        # 1.32.0.0/15  (1.32.0.1/32, 1.32.0.2/32, 1.32.192.1/32, 1.32.129.1/32, 1.33.0.1/32, 1.33.0.2/32) <<-
+        self.assertSetEqual(
+            set(self.networks["1.32.0.0/16"].events.all()),
+            {
+                self.events["1.32.0.1/32"],
+                self.events["1.32.0.2/32"],
+                self.events["1.32.192.1/32"],
+                self.events["1.32.129.1/32"],
+                self.events["1.33.0.1/32"],
+                self.events["1.33.0.2/32"],
+            },
+        )
+
+    def test_loop_ascendant_level0(self):
+        self.ipv4_1.parent = self.ipv4_1
+        self.assertRaises(ValidationError, self.ipv4_1.save)
+
+    def test_loop_ascendant_level1(self):
+        self.ipv4_1.parent = self.ipv4_1_3
+        self.assertRaises(ValidationError, self.ipv4_1.save)
+
+    def test_loop_descendant_level0(self):
+        self.ipv4_1.children.add(self.ipv4_1)
+        self.assertRaises(ValidationError, self.ipv4_1.save)
+
+    def test_loop_descendant_level1(self):
+        self.ipv4_1_2.children.add(self.ipv4_1)
+        self.assertRaises(ValidationError, self.ipv4_1_2.save)

--- a/ngen/views/constituency.py
+++ b/ngen/views/constituency.py
@@ -230,9 +230,6 @@ class ContactCheckViewSet(viewsets.ModelViewSet):
             contact_id=contact_id
         ).order_by("-created")
         serializer = self.get_serializer(contact_checks, many=True)
-        print(
-            f"Contact checks for contact_id {contact_id}: {serializer.data} {len(contact_checks)}"
-        )
         return Response(serializer.data[:1], status=status.HTTP_200_OK)
 
     @action(


### PR DESCRIPTION
This pull request introduces several improvements to the handling of hierarchical relationships and event/network updates in the constituency models, as well as a minor cleanup in the views. The most significant changes focus on ensuring data integrity when updating or deleting network objects, preventing loops in parent relationships, and refactoring event and network reordering logic.

### Hierarchy & Data Integrity Improvements

* Added loop detection in the `parent` relationship validation to prevent cycles by tracking visited nodes in `ngen/models/common/mixins.py`. [[1]](diffhunk://#diff-2ce14d1b359c7af0778fe5a8ceb1acca0a8ea86e4dbcc077b2ef4aaedc864e4bR119-R122) [[2]](diffhunk://#diff-2ce14d1b359c7af0778fe5a8ceb1acca0a8ea86e4dbcc077b2ef4aaedc864e4bR132)

### Event & Network Reordering Logic

* Refactored the `save` method in `ngen/models/constituency.py` to properly reorder events and networks when a network is updated, including handling changes in parent relationships and network attributes.
* Added private helper methods (`_reorder_events_of_my_parent_and_me`, `_reorder_networks_that_belongs_to_me`) to encapsulate and clarify event/network reordering logic.
* Updated the `delete` method in `ngen/models/constituency.py` to ensure that child networks and related events are correctly reassigned to the parent network upon deletion.

### Code Cleanup

* Removed unnecessary debug print statements from the `get_by_contact_id` view in `ngen/views/constituency.py` for cleaner API responses.