### PR TITLE
Feature/refresh popup on version change

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ngen-frontend:
-    image: certunlp/ngen-frontend:2
+    image: certunlp/ngen-frontend:latest
     restart: always
     volumes:
       - ./data_static:/app/staticfiles
@@ -11,7 +11,7 @@ services:
       - "80:80"
 
   ngen-django:
-    image: certunlp/ngen-django:2
+    image: certunlp/ngen-django:latest
     restart: always
     entrypoint: ./docker/entrypoint.sh
     command: gunicorn project.wsgi:application --bind 0.0.0.0:8000
@@ -27,7 +27,7 @@ services:
       - ngen-redis
 
   ngen-celery-worker:
-    image: certunlp/ngen-django:2
+    image: certunlp/ngen-django:latest
     restart: always
     command: celery -A project worker -l warning
     env_file:
@@ -39,7 +39,7 @@ services:
       - ngen-redis
 
   ngen-celery-beat:
-    image: certunlp/ngen-django:2
+    image: certunlp/ngen-django:latest
     restart: always
     command: celery -A project beat -l warning
     env_file:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ngen-frontend:
-    image: certunlp/ngen-frontend:latest
+    image: certunlp/ngen-frontend:2
     restart: always
     volumes:
       - ./data_static:/app/staticfiles
@@ -11,7 +11,7 @@ services:
       - "80:80"
 
   ngen-django:
-    image: certunlp/ngen-django:latest
+    image: certunlp/ngen-django:2
     restart: always
     entrypoint: ./docker/entrypoint.sh
     command: gunicorn project.wsgi:application --bind 0.0.0.0:8000
@@ -27,7 +27,7 @@ services:
       - ngen-redis
 
   ngen-celery-worker:
-    image: certunlp/ngen-django:latest
+    image: certunlp/ngen-django:2
     restart: always
     command: celery -A project worker -l warning
     env_file:
@@ -39,7 +39,7 @@ services:
       - ngen-redis
 
   ngen-celery-beat:
-    image: certunlp/ngen-django:latest
+    image: certunlp/ngen-django:2
     restart: always
     command: celery -A project beat -l warning
     env_file:

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -46,6 +46,13 @@ COPY nginx-prod/nginx.conf.template.no-ssl /etc/nginx/nginx.conf.template.no-ssl
 COPY nginx-prod/docker-entrypoint.sh /docker-entrypoint.sh
 
 # Add version information
+ARG APP_VERSION_TAG
+ARG APP_COMMIT
+ARG APP_BRANCH
+ENV VITE_APP_VERSION_TAG=$APP_VERSION_TAG
+ENV VITE_APP_COMMIT=$APP_COMMIT
+ENV VITE_APP_BRANCH=$APP_BRANCH
+ENV VITE_APP_BUILD_FILE="prod"
 RUN echo "{\"tag\": \"$VITE_APP_VERSION_TAG\", \"commit\": \"$VITE_APP_COMMIT\", \"branch\": \"$VITE_APP_BRANCH\", \"build_file\": \"$VITE_APP_BUILD_FILE\"}" > /usr/share/nginx/html/version.json
 
 # Give permissions to the entry script

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,6 +54,7 @@
         "react-router-dom": "^6.26.0",
         "react-select": "^5.8.0",
         "react-toastify": "^10.0.5",
+        "react-update-popup": "^2.1.1",
         "react18-json-view": "^0.2.9",
         "redux": "^4.2.1",
         "redux-form": "^8.3.10",
@@ -8763,6 +8764,18 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-update-popup": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-update-popup/-/react-update-popup-2.1.1.tgz",
+      "integrity": "sha512-Vt/e0RQVmeLBgBYaBAMH2k3jVZlwSomzTFaUOgJ1gePJYCurcoyWcrDRh58yNQx38+3NUN5FUyQC01/DYdB/4A==",
+      "license": "MIT",
+      "dependencies": {
+        "swr": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/react18-json-view": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/react18-json-view/-/react18-json-view-0.2.9.tgz",
@@ -9570,6 +9583,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+      "integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
@@ -9947,10 +9973,12 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "react-router-dom": "^6.26.0",
     "react-select": "^5.8.0",
     "react-toastify": "^10.0.5",
+    "react-update-popup": "^2.1.1",
     "react18-json-view": "^0.2.9",
     "redux": "^4.2.1",
     "redux-form": "^8.3.10",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,9 +4,12 @@ import { BrowserRouter } from "react-router-dom";
 import routes, { renderRoutes } from "routes";
 import Alert from "components/Alert/Alert";
 import { useTokenManager } from "hooks/useTokenManager";
+import { useVersionPopup } from "hooks/useVersionPopup";
 
 const App = () => {
   useTokenManager();
+
+  const { VersionPopup } = useVersionPopup();
 
   return (
     <>
@@ -14,6 +17,7 @@ const App = () => {
       <BrowserRouter basename={import.meta.env.VITE_APP_BASE_NAME}>
         {renderRoutes(routes)}
       </BrowserRouter>
+      <VersionPopup />
     </>
   );
 };

--- a/frontend/src/hooks/useVersionPopup.jsx
+++ b/frontend/src/hooks/useVersionPopup.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { UpdateNotification } from "react-update-popup";
+// import "react-update-popup/dist/index.css";
+
+export const useVersionPopup = () => {
+  const [latestVersion, setLatestVersion] = useState(null);
+  const key_version = "last-frontend-version";
+
+  // Function that checks if there is a new version
+  const checkHasUpdate = async () => {
+    try {
+      const res = await fetch("/version.json", { cache: "no-store" });
+      const data = await res.json();
+
+      const storedVersion = localStorage.getItem(key_version);
+
+      if (!storedVersion) {
+        // First time load, store the version
+        localStorage.setItem(key_version, data.tag);
+        setLatestVersion(data.tag);
+        return false; // no popup on first load
+      }
+
+      if (storedVersion !== data.tag) {
+        setLatestVersion(data.tag);
+        return true; // new version: popup shows
+      }
+
+      return false; // same version
+    } catch (err) {
+      console.error("Error checking version:", err);
+      return false; // fallback
+    }
+  };
+
+  const onReload = () => {
+    if (latestVersion) {
+      localStorage.setItem(key_version, latestVersion);
+    }
+    window.location.reload(true);
+  };
+
+  const VersionPopup = () => (
+    <UpdateNotification
+      title="New Version Available"
+      description="There is a new version of the frontend. Refresh the page to update."
+      buttonText="Refresh"
+      refreshInterval={30_000} // every 30 seconds
+      checkHasUpdate={checkHasUpdate}
+      onReload={onReload}
+    />
+  );
+
+  return { VersionPopup };
+};
+
+export default useVersionPopup;


### PR DESCRIPTION
This pull request introduces a new mechanism to notify users when a new version of the frontend is available, prompting them to refresh the page to get the latest updates. It does this by adding a version popup component, updating the build process to include version information, and adding the necessary dependencies for the popup functionality.

**Version update notification feature:**
* Added a custom hook `useVersionPopup` that checks for frontend updates by comparing the current version tag in `/version.json` with the last seen version in local storage, and displays a popup using `react-update-popup` when a new version is available. (`frontend/src/hooks/useVersionPopup.jsx`)
* Integrated the `VersionPopup` component into the main `App` component so users are notified of new frontend versions. (`frontend/src/App.jsx`)

**Build and environment improvements:**
* Updated the production Dockerfile to inject version information (`APP_VERSION_TAG`, `APP_COMMIT`, `APP_BRANCH`, and build file) into the environment and write it to `/usr/share/nginx/html/version.json` for use by the update notification system. (`frontend/Dockerfile.prod`)

**Dependency management:**
* Added `react-update-popup` as a new dependency to support the version notification popup. (`frontend/package.json`, `frontend/package-lock.json`) [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R60) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR57) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR8767-R8778)
* Added `swr` and updated `use-sync-external-store` to support the new popup component's requirements. (`frontend/package-lock.json`) [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR9586-R9598) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL9950-R9981)