### PR TITLE
feat: add initial_notification_date to Event and notification_delay_s…

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -37,6 +37,7 @@
   "date.limit.response": "Response deadline",
   "date.minutes": "Minute/s",
   "date.one": "Date",
+  "date.optional": "(optional)",
   "date.other": "Dates",
   "derived.issue.preview": "Preview of derived issue",
   "editTransition": "Edit transition",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -37,7 +37,7 @@
   "date.limit.response": "Response deadline",
   "date.minutes": "Minute/s",
   "date.one": "Date",
-  "date.optional": "(optional)",
+  "date.optional": "optional",
   "date.other": "Dates",
   "derived.issue.preview": "Preview of derived issue",
   "editTransition": "Edit transition",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -37,7 +37,7 @@
   "date.limit.response": "Plazo de respuesta",
   "date.minutes": "Minuto/s",
   "date.one": "Fecha",
-  "date.optional": "(opcional)",
+  "date.optional": "opcional",
   "date.other": "Fechas",
   "derived.issue.preview": "Vista previa del problema derivado",
   "editTransition": "Editar transición",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -37,6 +37,7 @@
   "date.limit.response": "Plazo de respuesta",
   "date.minutes": "Minuto/s",
   "date.one": "Fecha",
+  "date.optional": "(opcional)",
   "date.other": "Fechas",
   "derived.issue.preview": "Vista previa del problema derivado",
   "editTransition": "Editar transición",

--- a/frontend/src/components/Field/DateShowField.jsx
+++ b/frontend/src/components/Field/DateShowField.jsx
@@ -57,6 +57,11 @@ const DateShowField = ({ value, year = true, time = true, seconds = false, asFor
   };
 
   useEffect(() => {
+    if (!value) {
+      setDate("--");
+      setTitle("--");
+      return;
+    }
     let d = new Date(value);
     setDate(d.toLocaleDateString(options["locale"], options));
     setTitle(`${d.toLocaleDateString(optionsFullLocal["locale"], optionsFullLocal)}\n${d.toLocaleDateString(optionsFull["locale"], optionsFull)}`);

--- a/frontend/src/views/event/CreateEvent.jsx
+++ b/frontend/src/views/event/CreateEvent.jsx
@@ -165,7 +165,9 @@ const CreateEvent = ({ routeParams }) => {
   const createEvent = ({ simulate = false } = {}) => {
     const formDataEvent = new FormData();
 
-    formDataEvent.append("date", body.date); // tengo que hacer esto porque solo me acepta este formato, ver a futuro
+    if (body.date) {
+      formDataEvent.append("date", body.date);
+    }
     formDataEvent.append("priority", body.priority);
     formDataEvent.append("tlp", body.tlp);
     formDataEvent.append("taxonomy", body.taxonomy);

--- a/frontend/src/views/event/EditEvent.jsx
+++ b/frontend/src/views/event/EditEvent.jsx
@@ -45,7 +45,7 @@ const EditEvent = ({ routeParams }) => {
       getEvent(COMPONENT_URL.event + id + "/")
         .then((response) => {
           response.data.case = response.data.case ? response.data.case : "";
-          response.data.date = response.data.date.substring(0, 16);
+          response.data.date = response.data.date ? response.data.date.substring(0, 16) : null;
           setBody(response.data);
         })
         .catch((error) => console.log(error));
@@ -174,7 +174,9 @@ const EditEvent = ({ routeParams }) => {
       }
       //console.log(fecha.toISOString())//YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]
 
-      formDataEvent.append("date", body.date); // tengo que hacer esto porque solo me acepta este formato, ver a futuro
+      if (body.date) {
+        formDataEvent.append("date", body.date);
+      }
       //f.append("date", fecha.toISOString())
       formDataEvent.append("priority", body.priority);
       formDataEvent.append("tlp", body.tlp);
@@ -235,7 +237,9 @@ const EditEvent = ({ routeParams }) => {
       }
       //console.log(fecha.toISOString())//YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]
 
-      formDataEvent.append("date", body.date); // tengo que hacer esto porque solo me acepta este formato, ver a futuro
+      if (body.date) {
+        formDataEvent.append("date", body.date);
+      }
       //f.append("date", fecha.toISOString())
       formDataEvent.append("priority", body.priority);
       formDataEvent.append("tlp", body.tlp);

--- a/frontend/src/views/event/ModalCreateEvent.jsx
+++ b/frontend/src/views/event/ModalCreateEvent.jsx
@@ -140,7 +140,9 @@ const ModalCreateEvent = ({
 
   const createEvent = () => {
     const formDataEvent = new FormData();
-    formDataEvent.append("date", body.date); // tengo que hacer esto porque solo me acepta este formato, ver a futuro
+    if (body.date) {
+      formDataEvent.append("date", body.date);
+    }
     formDataEvent.append("priority", body.priority);
     formDataEvent.append("tlp", body.tlp);
     formDataEvent.append("taxonomy", body.taxonomy);

--- a/frontend/src/views/event/components/FormEvent.jsx
+++ b/frontend/src/views/event/components/FormEvent.jsx
@@ -28,7 +28,13 @@ import { useTranslation } from "react-i18next";
 import Modal from "react-bootstrap/Modal";
 
 const FormEvent = (props) => {
-  const [date, setDate] = useState(props.body.date ? props.body.date.substring(0, 16) : getCurrentDateTime());
+  const [date, setDate] = useState(
+    props.body.date
+      ? props.body.date.substring(0, 16)
+      : props.body.date === null
+        ? ""
+        : getCurrentDateTime()
+  );
   const [artifactsValueLabel, setArtifactsValueLabel] = useState([]);
   const [modalCreate, setModalCreate] = useState(false);
   const [typeArtifact, setTypeArtifact] = useState("0");
@@ -470,21 +476,21 @@ const FormEvent = (props) => {
                 <Form.Group controlId="formGridAddress1">
                   <Form.Label>
                     {t("date.one")}
-                    <b style={{ color: "red" }}>*</b>
+                    <i className="text-muted ms-1" style={{ fontSize: "0.85rem" }}>({t("date.optional")})</i>
                   </Form.Label>
                   <Form.Control
                     type="datetime-local"
                     maxLength="150"
-                    max={getCurrentDateTime()}
                     value={date}
-                    isInvalid={new Date(date) > new Date(getCurrentDateTime())}
+                    isInvalid={date && new Date(date) > new Date(getCurrentDateTime())}
                     onChange={(e) => {
-                      completeField(e);
-                      setDate(e.target.value);
+                      const val = e.target.value;
+                      completeField({ target: { name: "date", value: val || null } });
+                      setDate(val);
                     }}
                     name="date"
                   />
-                  {new Date(date) > new Date(getCurrentDateTime()) ? <div className="invalid-feedback">{t("date.invalid")}</div> : ""}
+                  {date && new Date(date) > new Date(getCurrentDateTime()) ? <div className="invalid-feedback">{t("date.invalid")}</div> : ""}
                 </Form.Group>
               </Col>
               <Col sm={12} lg={4}>

--- a/ngen/migrations/0034_event_date_nullable.py
+++ b/ngen/migrations/0034_event_date_nullable.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ngen", "0033_view_about_page_permission"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="event",
+            name="date",
+            field=models.DateTimeField(
+                blank=True,
+                default=None,
+                null=True,
+            ),
+        ),
+    ]

--- a/ngen/models/case.py
+++ b/ngen/models/case.py
@@ -592,7 +592,7 @@ class Event(
     # TaggedItemMixin,
 ):
     tlp = models.ForeignKey("ngen.Tlp", models.PROTECT)
-    date = models.DateTimeField(default=timezone.now)
+    date = models.DateTimeField(null=True, blank=True, default=None)
 
     network = models.ForeignKey(
         "ngen.Network",

--- a/ngen/serializers/case.py
+++ b/ngen/serializers/case.py
@@ -133,6 +133,7 @@ class EventSerializer(
 
     def get_extra_kwargs(self):
         extra_kwargs = super().get_extra_kwargs()
+        extra_kwargs["date"] = {"allow_null": True, "required": False}
         action = self.context["view"].action
         if action in ["update", "partial_update", "retrieve"]:
             if self.instance and self.instance.is_parent():


### PR DESCRIPTION
…econds to Case for MTTR measurement

- Add Event.initial_notification_date (optional DateTimeField) to store external detection timestamp (e.g. IntelMQ time.observation)
- Add Case.notification_delay_seconds (FloatField) calculated on first transition to attended state
- Update EventSerializer and CaseSerializer to expose new fields
- Add migration 0024