### PR TITLE
fix repeated elements on list

### DIFF
--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -142,6 +142,7 @@ def contact_summary(
             )
             .prefetch_related("events")
             .order_by("priority__severity")
+            .distinct()
         )
         list_open_cases = [
             {"case": case, "events": case.events.filter(network__contacts=contact)}
@@ -149,11 +150,15 @@ def contact_summary(
         ]
 
         # Get all closed cases for the contact of last week
-        closed_cases = ngen.models.Case.objects.filter(
-            state__solved=True,
-            events__network__contacts=contact,
-            solve_date__gte=timezone.now() - timedeltavalue,
-        ).prefetch_related("events")
+        closed_cases = (
+            ngen.models.Case.objects.filter(
+                state__solved=True,
+                events__network__contacts=contact,
+                solve_date__gte=timezone.now() - timedeltavalue,
+            )
+            .prefetch_related("events")
+            .distinct()
+        )
 
         list_closed_cases = [
             {"case": case, "events": case.events.filter(network__contacts=contact)}
@@ -289,9 +294,13 @@ def export_events_for_email_task(email, days=14):
         timedeltavalue = timezone.timedelta(days=days)
 
         # Open cases
-        open_cases = ngen.models.Case.objects.filter(
-            state__attended=True, events__network__contacts=contact
-        ).prefetch_related("events")
+        open_cases = (
+            ngen.models.Case.objects.filter(
+                state__attended=True, events__network__contacts=contact
+            )
+            .prefetch_related("events")
+            .distinct()
+        )
 
         list_open_cases = [
             {"case": case, "events": case.events.filter(network__contacts=contact)}
@@ -305,11 +314,15 @@ def export_events_for_email_task(email, days=14):
         exported_data = ngen.models.Event.export_events_to_zip(events_to_export)
 
         # Closed cases
-        closed_cases = ngen.models.Case.objects.filter(
-            state__solved=True,
-            events__network__contacts=contact,
-            solve_date__gte=timezone.now() - timedeltavalue,
-        ).prefetch_related("events")
+        closed_cases = (
+            ngen.models.Case.objects.filter(
+                state__solved=True,
+                events__network__contacts=contact,
+                solve_date__gte=timezone.now() - timedeltavalue,
+            )
+            .prefetch_related("events")
+            .distinct()
+        )
 
         list_closed_cases = [
             {"case": case, "events": case.events.filter(network__contacts=contact)}

--- a/ngen/tests/models/test_announcement.py
+++ b/ngen/tests/models/test_announcement.py
@@ -1,7 +1,8 @@
+from gettext import translation
+
 from constance.test import override_config
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase
-from django.test import override_settings
+from django.test import TestCase, override_settings
 from django.utils.translation import gettext_lazy
 from django.core import mail
 from unittest.mock import patch
@@ -969,9 +970,11 @@ class AnnouncementTestCase(TestCase):
 
     @patch("django.core.mail.backends.smtp.EmailBackend")
     @use_test_email_env()
-    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True, LANGUAGE_CODE="en")
     @override_config(CASE_REPORT_NEW_CASES=True)
     @override_config(TEAM_EMAIL="team@ngen.com")
+    @override_config(SUMMARY_TLP="red")
+    @override_config(TEAM_NAME="TEAM")
     @override_config(NGEN_LANG="en")
     def test_summary_emailbackend(self, mock_backend):
         """
@@ -979,6 +982,11 @@ class AnnouncementTestCase(TestCase):
 
         Checks directly the content of the email sent, as well as the subject and the recipient.
         """
+        from django.utils import translation
+
+        translation.activate("en")
+        self.addCleanup(translation.deactivate)
+
         from django.core.mail import get_connection
 
         mock_backend.return_value = get_connection(

--- a/ngen/tests/models/test_announcement.py
+++ b/ngen/tests/models/test_announcement.py
@@ -4,9 +4,9 @@ from constance.test import override_config
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.utils.translation import gettext_lazy
+from django.utils import timezone
 from django.core import mail
 from unittest.mock import patch
-from datetime import datetime
 
 from ngen import tasks
 from ngen.models import (
@@ -1047,8 +1047,6 @@ class AnnouncementTestCase(TestCase):
 
         self.assertIn("Solved cases: 1", email.body)
 
-        print("Email body: ", email.body)
-
         ev1_id = str(event1.uuid).split("-")[0]
         ev2_id = str(event2.uuid).split("-")[0]
 
@@ -1068,17 +1066,15 @@ class AnnouncementTestCase(TestCase):
 
         self.assertIn("Solved cases: 1", email.body)
 
-        print("Email body: ", email.body)
-
         ev1_id = str(event1.uuid).split("-")[0]
         ev2_id = str(event2.uuid).split("-")[0]
 
         # ev1_id and ev2_id should appear just once in the email body, as well as the notes of each event.
         self.assertEqual(email.body.count(ev1_id), 1)
         self.assertEqual(email.body.count(ev2_id), 1)
-        # filemname example events_20260417_163913_18b445.zip
+        # filename example events_20260417_163913_18b445.zip
         attachment_name = email.attachments[0][0]
-        now = datetime.now().strftime("%Y%m%d")
+        now = timezone.now().strftime("%Y%m%d")
 
         self.assertTrue(attachment_name.startswith(f"events_{now}_"))
         self.assertTrue(attachment_name.endswith(".zip"))

--- a/ngen/tests/models/test_announcement.py
+++ b/ngen/tests/models/test_announcement.py
@@ -3,7 +3,11 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test import override_settings
 from django.utils.translation import gettext_lazy
+from django.core import mail
+from unittest.mock import patch
+from datetime import datetime
 
+from ngen import tasks
 from ngen.models import (
     Evidence,
     ContentType,
@@ -962,3 +966,111 @@ class AnnouncementTestCase(TestCase):
             "team@ngen.com",
             intern_channel_2.get_last_message().recipients[0]["email"],
         )
+
+    @patch("django.core.mail.backends.smtp.EmailBackend")
+    @use_test_email_env()
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    @override_config(CASE_REPORT_NEW_CASES=True)
+    @override_config(TEAM_EMAIL="team@ngen.com")
+    @override_config(NGEN_LANG="en")
+    def test_summary_emailbackend(self, mock_backend):
+        """
+        Send summary email with the correct information.
+
+        Checks directly the content of the email sent, as well as the subject and the recipient.
+        """
+        from django.core.mail import get_connection
+
+        mock_backend.return_value = get_connection(
+            "django.core.mail.backends.locmem.EmailBackend"
+        )
+
+        # Create first event and assign to case
+        event1 = Event.objects.create(
+            domain="info.unlp.edu.ar",
+            taxonomy=Taxonomy.objects.get(slug="botnet"),
+            feed=Feed.objects.get(slug="csirtamericas"),
+            tlp=Tlp.objects.get(slug="green"),
+            reporter=User.objects.get(username="ngen"),
+            notes="event1 notes",
+            priority=Priority.objects.get(slug="high"),
+            avoid_auto_merge=True,
+        )
+        event1.save()
+        case = Case.objects.create(
+            state=State.objects.get(slug="open"),
+            tlp=Tlp.objects.get(slug="green"),
+            priority=Priority.objects.get(slug="high"),
+        )
+        case.save()
+
+        # Assign event to case
+        event1.case = case
+        event1.save()
+
+        # Create second event and assign to case
+        event2 = Event.objects.create(
+            domain="info.unlp.edu.ar",
+            taxonomy=Taxonomy.objects.get(slug="botnet"),
+            feed=Feed.objects.get(slug="csirtamericas"),
+            tlp=Tlp.objects.get(slug="green"),
+            reporter=User.objects.get(username="ngen"),
+            notes="event2 notes",
+            priority=Priority.objects.get(slug="high"),
+            avoid_auto_merge=True,
+        )
+        event2.case = case
+        event2.save()
+        case.save()
+
+        # Close case
+        case.state = State.objects.get(slug="closed")
+        case.save()
+
+        # basic contact summary test
+        tasks.contact_summary.delay(contact_usernames=["soporte@cert.unlp.edu.ar"])
+
+        self.assertEqual(len(mail.outbox), 1)
+
+        email = mail.outbox[0]
+
+        self.assertEqual(email.subject, "[TEAM][TLP:RED] Summary")
+        self.assertEqual(email.to, ["soporte@cert.unlp.edu.ar"])
+
+        self.assertIn("Solved cases: 1", email.body)
+
+        print("Email body: ", email.body)
+
+        ev1_id = str(event1.uuid).split("-")[0]
+        ev2_id = str(event2.uuid).split("-")[0]
+
+        # ev1_id and ev2_id should appear just once in the email body, as well as the notes of each event.
+        self.assertEqual(email.body.count(ev1_id), 1)
+        self.assertEqual(email.body.count(ev2_id), 1)
+
+        # export summary test
+        tasks.export_events_for_email_task.delay("soporte@cert.unlp.edu.ar")
+
+        self.assertEqual(len(mail.outbox), 2)
+
+        email = mail.outbox[1]
+
+        self.assertEqual(email.subject, "[TEAM][TLP:RED] Full Summary")
+        self.assertEqual(email.to, ["soporte@cert.unlp.edu.ar"])
+
+        self.assertIn("Solved cases: 1", email.body)
+
+        print("Email body: ", email.body)
+
+        ev1_id = str(event1.uuid).split("-")[0]
+        ev2_id = str(event2.uuid).split("-")[0]
+
+        # ev1_id and ev2_id should appear just once in the email body, as well as the notes of each event.
+        self.assertEqual(email.body.count(ev1_id), 1)
+        self.assertEqual(email.body.count(ev2_id), 1)
+        # filemname example events_20260417_163913_18b445.zip
+        attachment_name = email.attachments[0][0]
+        now = datetime.now().strftime("%Y%m%d")
+
+        self.assertTrue(attachment_name.startswith(f"events_{now}_"))
+        self.assertTrue(attachment_name.endswith(".zip"))


### PR DESCRIPTION
This pull request improves the accuracy of case and event summaries sent via email and adds comprehensive tests for email notifications. The main changes include ensuring distinct cases are returned in queries to prevent duplicates, and adding a new test to validate the content and attachments of summary emails.

**Bug fixes and improvements to case/event queries:**

* Updated queries in `ngen/tasks.py` to use `.distinct()` when fetching open and closed cases in both `contact_summary` and `export_events_for_email_task`, ensuring that each case appears only once in the results. [[1]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387R145-R161) [[2]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387L292-R303) [[3]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387L308-R325)

**Testing and validation:**

* Added a new test `test_summary_emailbackend` in `ngen/tests/models/test_announcement.py` to verify that summary and export emails contain the correct subject, recipients, body content, and event/case details, as well as to check for the correct attachment naming and presence.
* Added necessary imports for email testing and mocking in `ngen/tests/models/test_announcement.py`.