### PR TITLE
new evidence notification

### DIFF
--- a/ngen/locale/es/LC_MESSAGES/django.po
+++ b/ngen/locale/es/LC_MESSAGES/django.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-18 12:00+0000\n"
+"POT-Creation-Date: 2026-04-28 18:16+0000\n"
 "PO-Revision-Date: 2024-09-10 10:30+0000\n"
 "Last-Translator: Mateo Durante <mdurante@cert.unlp.edu.ar>\n"
 "Language-Team: en/es <soporte@cert.unlp.edu.ar>\n"
@@ -64,23 +64,23 @@ msgstr ""
 "Indica si esta relación fue creada automáticamente y será eliminada si se "
 "modifica el objeto relacionado."
 
-#: ngen/models/case.py:53 project/settings.py:256
+#: ngen/models/case.py:55 project/settings.py:256
 msgid "Manual"
 msgstr "Manual"
 
-#: ngen/models/case.py:54 project/settings.py:257
+#: ngen/models/case.py:56 project/settings.py:257
 msgid "Auto"
 msgstr "Automático"
 
-#: ngen/models/case.py:55 project/settings.py:258
+#: ngen/models/case.py:57 project/settings.py:258
 msgid "Auto open"
 msgstr "Apertura automática"
 
-#: ngen/models/case.py:56 project/settings.py:259
+#: ngen/models/case.py:58 project/settings.py:259
 msgid "Auto close"
 msgstr "Cierre automático"
 
-#: ngen/models/case.py:274
+#: ngen/models/case.py:276
 #, python-format
 msgid ""
 "It's not possible to change the state %s to %s. The new possible states are "
@@ -88,7 +88,17 @@ msgid ""
 msgstr ""
 "No es posible cambiar el estado %s a %s. Los nuevos estados posibles son %s."
 
-#: ngen/models/case.py:698
+#: ngen/models/case.py:633
+msgid ""
+"If true, this event will not be automatically merged with other events even "
+"if they have the same taxonomy, feed, cidr and domain. Can be merged "
+"manually with any event."
+msgstr ""
+"Si es verdadero, este evento no se fusionará automáticamente con otros eventos "
+"incluso si tienen la misma taxonomía, feed, cidr y dominio. Puede fusionarse "
+"manualmente con cualquier evento."
+
+#: ngen/models/case.py:809
 msgid "Date cannot be in the future"
 msgstr "La fecha no puede estar en el futuro"
 
@@ -96,23 +106,23 @@ msgstr "La fecha no puede estar en el futuro"
 msgid "Parent can't be a descendant of the instance."
 msgstr "El padre no puede ser un descendiente de la instancia."
 
-#: ngen/models/common/mixins.py:178
+#: ngen/models/common/mixins.py:182
 msgid "The parent must not be the same instance."
 msgstr "El padre no debe ser la misma instancia."
 
-#: ngen/models/common/mixins.py:182
+#: ngen/models/common/mixins.py:186
 msgid "The parent is not mergeable or is blocked."
 msgstr "El padre no es fusionable o está bloqueado."
 
-#: ngen/models/common/mixins.py:186
+#: ngen/models/common/mixins.py:190
 msgid "The child is not mergeable or is blocked."
 msgstr "El hijo no es fusionable o está bloqueado."
 
-#: ngen/models/common/mixins.py:216
+#: ngen/models/common/mixins.py:220
 msgid "Parent of merged instances can't be modified"
 msgstr "Las instancias fusionadas no pueden ser modificadas."
 
-#: ngen/models/common/mixins.py:242
+#: ngen/models/common/mixins.py:246
 #, python-brace-format
 msgid ""
 "Merged instances can't be modified: {self}, {self.parent}, {self.children}"
@@ -120,12 +130,12 @@ msgstr ""
 "Las instancias fusionadas no pueden ser modificadas: {self}, {self.parent}, "
 "{self.children}."
 
-#: ngen/models/common/mixins.py:256
+#: ngen/models/common/mixins.py:260
 #, python-brace-format
 msgid "{attr} of blocked instances can't be modified"
 msgstr "{attr} de las instancias bloqueadas no puede ser modificado"
 
-#: ngen/models/common/mixins.py:465
+#: ngen/models/common/mixins.py:468
 msgid "Address must be either a CIDR or a domain"
 msgstr "La dirección debe ser un CIDR o un dominio"
 
@@ -226,7 +236,7 @@ msgstr "Una taxonomía interna con padre no puede tener alias"
 msgid "Internal taxonomy alias cannot have parent"
 msgstr "Un alias de taxonomía interna no puede tener padre"
 
-#: ngen/serializers/case.py:160
+#: ngen/serializers/case.py:162
 #, python-format
 msgid "%s of merged events can't be modified"
 msgstr "%s de los eventos fusionados no pueden ser modificados"
@@ -299,7 +309,7 @@ msgid "A new event has been added to the case %(id)s"
 msgstr "Se ha agregado un nuevo evento al caso %(id)s"
 
 #: ngen/templates/reports/case_change_state.html:7
-#: ngen/tests/models/test_announcement.py:525
+#: ngen/tests/models/test_announcement.py:530
 msgid "Case status updated"
 msgstr "Estado del caso actualizado"
 
@@ -342,8 +352,8 @@ msgid ""
 "We are reviewing our records to ensure we have your most up-to-date "
 "information."
 msgstr ""
-"Estamos revisando nuestros registros para asegurarnos de tener su información "
-"más actualizada."
+"Estamos revisando nuestros registros para asegurarnos de tener su "
+"información más actualizada."
 
 #: ngen/templates/reports/contact_check.html:22
 #: ngen/templates/reports/contact_check_submitted.html:35
@@ -419,8 +429,8 @@ msgid ""
 "<strong>Note:</strong> If we don't receive your confirmation, we'll remove "
 "your details from our system."
 msgstr ""
-"<strong>Nota:</strong> Si no recibimos su confirmación, eliminaremos "
-"su información de nuestro sistema."
+"<strong>Nota:</strong> Si no recibimos su confirmación, eliminaremos su "
+"información de nuestro sistema."
 
 #: ngen/templates/reports/contact_check_submitted.html:8
 #, python-format
@@ -432,8 +442,8 @@ msgid ""
 "The following is a summary of the contact's submitted verification and "
 "associated information."
 msgstr ""
-"A continuación se muestra un resumen de la verificación enviada "
-"del contacto y la información asociada."
+"A continuación se muestra un resumen de la verificación enviada del contacto "
+"y la información asociada."
 
 #: ngen/templates/reports/contact_check_submitted.html:23
 msgid "Contact details:"
@@ -503,6 +513,22 @@ msgstr "Recomendaciones"
 msgid "For more information"
 msgstr "Para obtener más información"
 
+#: ngen/templates/reports/new_evidence_added_to_case.html:6
+msgid "New evidence added to case"
+msgstr "Nueva evidencia agregada al caso"
+
+#: ngen/templates/reports/new_evidence_added_to_case.html:12
+msgid "A new evidence has been added to the case %(id)s"
+msgstr "Se ha agregado nueva evidencia al caso %(id)s"
+
+#: ngen/templates/reports/new_evidence_added_to_event.html:6
+msgid "New evidence added to event"
+msgstr "Nueva evidencia agregada al evento"
+
+#: ngen/templates/reports/new_evidence_added_to_event.html:12
+msgid "A new evidence has been added to the event %(id)s"
+msgstr "Se ha agregado un nueva evidencia al evento %(id)s"
+
 #: ngen/templates/reports/summary_case_detail_closed.html:5
 msgid "Solved cases"
 msgstr "Casos resueltos"
@@ -548,8 +574,8 @@ msgid ""
 "If you would like to see more details, you can export the full report from: "
 "<a href=\"%(link)s\">%(link)s</a>"
 msgstr ""
-"Si desea ver más detalles, puede exportar el informe completo desde: "
-"<a href=\"%(link)s\">%(link)s</a>"
+"Si desea ver más detalles, puede exportar el informe completo desde: <a "
+"href=\"%(link)s\">%(link)s</a>"
 
 #: ngen/templates/reports/summary_contact.html:31
 msgid "Congratulation! You have <strong>0</strong> unsolved cases"
@@ -568,10 +594,11 @@ msgid "A retest is already in progress for this event."
 msgstr "Ya hay una nueva prueba en curso para este evento."
 
 #: ngen/views/case.py:158
+#, python-brace-format
 msgid "Task retest event for {event.pk} launched"
 msgstr "Tarea de nueva prueba del evento para {event.pk} lanzada"
 
-#: ngen/views/case.py:306
+#: ngen/views/case.py:425
 msgid "Task create cases for matching events launched"
 msgstr "Tarea de creación de casos para eventos coincidentes lanzada"
 
@@ -719,70 +746,97 @@ msgstr "Ciclo de vida predeterminado del caso"
 msgid "Send report on new cases"
 msgstr "Enviar informe sobre nuevos casos"
 
-#: project/settings.py:409
+#: project/settings.py:410
+msgid ""
+"Report events with external network to affected contact emails from RDAP, "
+"WHOIS, etc."
+msgstr ""
+"Reportar eventos con red externa a los correos electrónicos de contacto afectados "
+"de RDAP, WHOIS, etc."
+
+#: project/settings.py:418
+msgid "Create internal communication channel for each case automatically"
+msgstr "Crear un canal de comunicación interno para cada caso automáticamente"
+
+#: project/settings.py:429
+#, python-brace-format
+msgid ""
+"Case email subject template. Variables: {team_name}, {tlp}, {channel_type}, "
+"{uuid}, {short_uuid}. Double spaces and empty [] will be removed "
+"automatically."
+msgstr ""
+"Plantilla de asunto de correo electrónico del caso. Variables: {team_name}, "
+"{tlp}, {channel_type}, {uuid}, {short_uuid}. Los espacios dobles y los [] "
+"vacíos se eliminarán automáticamente."
+
+#: project/settings.py:436
 msgid "Default priority"
 msgstr "Prioridad predeterminada"
 
-#: project/settings.py:414
+#: project/settings.py:441
+msgid "Default TLP"
+msgstr "TLP por defecto"
+
+#: project/settings.py:446
 msgid "Allowed artifact types"
 msgstr "Tipos de artefactos permitidos"
 
-#: project/settings.py:419
+#: project/settings.py:451
 msgid "Save enrichment even if it fails"
 msgstr "Guardar enriquecimiento incluso si falla"
 
-#: project/settings.py:424
+#: project/settings.py:456
 msgid "Enrich artifacts from artifacts enrichmets"
 msgstr "Enriquecer los artefactos a partir de sus enriquecimientos"
 
-#: project/settings.py:429
+#: project/settings.py:461
 msgid "Cortex host domain:port"
 msgstr "Dominio del host de Cortex:puerto"
 
-#: project/settings.py:434
+#: project/settings.py:466
 msgid "Cortex admin apikey"
 msgstr "Clave API de administrador de Cortex"
 
-#: project/settings.py:439
+#: project/settings.py:471
 msgid "Kintun host domain:port"
 msgstr "Dominio del host de Kintun:puerto"
 
-#: project/settings.py:444
+#: project/settings.py:476
 msgid "Kintun admin apikey"
 msgstr "Clave API de administrador de Kintun"
 
-#: project/settings.py:449
+#: project/settings.py:481
 msgid "Default page size"
 msgstr "Tamaño de página predeterminado"
 
-#: project/settings.py:454
+#: project/settings.py:486
 msgid "Max page size (use with caution)"
 msgstr "Tamaño máximo de página (usar con precaución)"
 
-#: project/settings.py:459
+#: project/settings.py:491
 msgid "Auto merge events with same domain/cidr and traxonomy"
 msgstr "Fusión automática de eventos con el mismo dominio/cidr y taxonomía"
 
-#: project/settings.py:464
+#: project/settings.py:496
 msgid "Add `same feed` to the auto merge events condition"
 msgstr "Agregar `mismo feed` a la condición de fusión automática de eventos"
 
-#: project/settings.py:470
+#: project/settings.py:502
 msgid ""
 "Add an optional time window to the auto merge events condition (0 disabled)"
 msgstr ""
 "Agregar una ventana de tiempo opcional a la condición de fusión automática "
 "de eventos (0 deshabilitado)"
 
-#: project/settings.py:476
+#: project/settings.py:508
 msgid "Default TLP for summary"
 msgstr "TLP por defecto para el resumen"
 
-#: project/settings.py:480
+#: project/settings.py:512
 msgid "Full summary public report link"
 msgstr "Enlace al informe público de resumen completo"
 
-#: project/settings.py:486
+#: project/settings.py:518
 msgid ""
 "Allow auto creation of taxonomies and groups by the slug on event creation"
 msgstr ""

--- a/ngen/mailer/email_handler.py
+++ b/ngen/mailer/email_handler.py
@@ -14,6 +14,8 @@ EMAIL_TEMPLATES = {
     "case_closed_report": "reports/case_closed_report.html",
     "case_change_state": "reports/case_change_state.html",
     "case_assign": "reports/case_assign.html",
+    "new_evidence_added_to_event": "reports/new_evidence_added_to_event.html",
+    "new_evidence_added_to_case": "reports/new_evidence_added_to_case.html",
 }
 
 
@@ -174,7 +176,7 @@ class EmailHandler:
             raise ValueError("Send email failed. Neither Body nor Template provided.")
 
         if template and template not in EMAIL_TEMPLATES:
-            raise ValueError("Send email failed. Invalid template")
+            raise ValueError(f"Send email failed. Invalid template: '{template}'.")
 
         rendered_template = {}
         if template:

--- a/ngen/models/case.py
+++ b/ngen/models/case.py
@@ -1035,12 +1035,15 @@ class Evidence(AuditModelMixin, ValidationModelMixin):
     def save(self, *args, **kwargs):
         """
         Set assigned_name, size, extension, mime and original_filename fields.
+        Also notify when a new evidence is added.
         assigned_name:
             1. strip the assigned_name removing leading and trailing whitespaces
             2. split the assigned_name by '.' and get the first part
             3. remove any non-word characters [^a-zA-Z0-9_]
             4. replace '_' with '-'
         """
+        is_new = self.pk is None
+
         if self.assigned_name:
             self.assigned_name = re.sub(
                 r"[\W]+", "-", self.assigned_name.strip().split(".")[0]
@@ -1049,7 +1052,25 @@ class Evidence(AuditModelMixin, ValidationModelMixin):
         self.size = self.file.size
         self.extension = Path(self.file.name).suffix
         self.mime = get_mime_type(self.file.open("rb"))
+
         super().save(*args, **kwargs)
+
+        # Post creation notification logic
+        if is_new:
+            related_obj = self.get_related()
+
+            # If the evidence was uploaded to an Event that has an associated Case
+            if isinstance(related_obj, Event) and related_obj.case:
+                # Passing send_attachments=True if we want the email to include the new file
+                related_obj.case.communicate_v2(
+                    "new_evidence_added_to_event", events=[related_obj]
+                )
+
+            # If the evidence was uploaded directly to the Case (not through an Event)
+            elif isinstance(related_obj, Case):
+                related_obj.communicate_v2(
+                    "new_evidence_added_to_case", send_attachments=True
+                )
 
 
 class CaseTemplate(AuditModelMixin, AddressModelMixin, ValidationModelMixin):

--- a/ngen/templates/reports/new_evidence_added_to_case.html
+++ b/ngen/templates/reports/new_evidence_added_to_case.html
@@ -1,0 +1,17 @@
+{% extends "reports/content_base.html" %}
+{% load i18n %}
+{% language lang %}
+    {% block content_header %}
+        <h4>
+            {% translate 'New evidence added to case' %}
+        </h4>
+    {% endblock %}
+
+    {% block content_body %}
+        <p class="lead">
+            {% blocktranslate trimmed with id=case.uuid %}
+                A new evidence has been added to the case {{ id }}
+            {% endblocktranslate %}
+        </p>
+    {% endblock %}
+{% endlanguage %}

--- a/ngen/templates/reports/new_evidence_added_to_event.html
+++ b/ngen/templates/reports/new_evidence_added_to_event.html
@@ -1,0 +1,20 @@
+{% extends "reports/content_base.html" %}
+{% load i18n %}
+{% language lang %}
+    {% block content_header %}
+        <h4>
+            {% translate 'New evidence added to event' %}
+        </h4>
+    {% endblock %}
+
+    {% block content_body %}
+        <p class="lead">
+            {% blocktranslate trimmed with id=case.uuid %}
+                A new evidence has been added to the event {{ id }}
+            {% endblocktranslate %}
+        </p>
+        {% for event in events %}
+            {% include "reports/event_detail.html" with event=event %}
+        {% endfor %}
+    {% endblock %}
+{% endlanguage %}

--- a/ngen/tests/api/test_events.py
+++ b/ngen/tests/api/test_events.py
@@ -1,6 +1,10 @@
 from datetime import timedelta
 
 from django.urls import reverse
+from django.test import override_settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from ngen.models.email_message import EmailMessage
+from ngen.models.state import State
 from rest_framework import status
 from rest_framework_simplejwt.tokens import Token
 
@@ -16,6 +20,8 @@ from ngen.models import (
     Artifact,
 )
 from ngen.tests.api.api_test_case_with_login import APITestCaseWithLogin
+from ngen.tests.test_helpers import use_test_email_env
+from constance.test import override_config
 
 
 class MyToken(Token):
@@ -122,7 +128,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             "cidr": "2.2.2.2",
             # 'domain': 'bbb',
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -138,7 +144,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             # 'cidr': '2.2.2.2',
             "domain": "info.unlp.edu.ar",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -154,7 +160,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             # 'cidr': '2.2.2.2',
             "domain": "info.unlp.edu.ar",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -174,7 +180,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             "cidr": "2.2.2.2",
             # 'domain': 'info.unlp.edu.ar',
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -194,7 +200,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             # 'cidr': '2.2.2.2',
             "domain": "info.unlp.edu.ar",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": "critical",
             "tlp": "amber",
             "taxonomy": "phishing",
@@ -211,7 +217,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             "cidr": "2.2.2.2",
             "domain": "info.unlp.edu.ar",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -227,7 +233,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             # 'cidr': '',
             # 'domain': 'info.unlp.edu.ar',
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -243,7 +249,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             "cidr": "",
             # 'domain': 'info.unlp.edu.ar',
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -259,7 +265,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             # 'cidr': '',
             "domain": "",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -275,7 +281,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             "cidr": "",
             "domain": "",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -291,7 +297,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             "cidr": "0.0.0.0/0",
             "domain": "",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -307,7 +313,7 @@ class TestEvent(APITestCaseWithLogin):
         json_data = {
             "cidr": "0.0.0.0/0",
             "domain": "*",
-            "notes": "estas son notas",
+            "notes": "these are notes",
             "priority": self.priority_url,
             "tlp": self.tlp_url,
             "taxonomy": self.taxonomy_url,
@@ -488,3 +494,128 @@ class TestEvent(APITestCaseWithLogin):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         with self.assertRaises(Case.DoesNotExist):
             Case.objects.get(pk=event_pk)
+
+    @use_test_email_env()
+    @override_config(CASE_REPORT_NEW_CASES=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_event_post_with_evidence(self):
+        """
+        This will test successful Event POST with an evidence file attached
+        """
+        initial_count = EmailMessage.objects.count()
+
+        # Create the new evidence file to upload
+        evidence_file = SimpleUploadedFile(
+            "file.txt", b"file_content", content_type="text/plain"
+        )
+
+        json_data = {
+            "address_value": "1.11.13.14",
+            "notes": "test",
+            "priority": self.priority_url,
+            "tlp": self.tlp_url,
+            "taxonomy": self.taxonomy_url,
+            "feed": self.feed_url,
+            "avoid_auto_merge": "false",
+            "evidence": evidence_file,  # Pass the simulated file
+        }
+
+        # Using format='multipart' is required so DRF handles form-data correctly
+        response = self.client.post(self.url_list, data=json_data, format="multipart")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Validate that the event was created
+        created_event = Event.objects.last()
+        self.assertIsNotNone(created_event)
+
+        self.assertEqual(EmailMessage.objects.count(), initial_count)
+        # NOTE: Depending on how your model stores evidence
+        # (e.g., a FileField on Event or a related model), you can add an assertion here.
+        # For example: self.assertTrue(created_event.evidences.exists())
+
+    @use_test_email_env()
+    @override_config(CASE_REPORT_NEW_CASES=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_event_put_add_evidence(self):
+        """
+        This will test successful Event PUT adding an extra evidence file
+        """
+        initial_count = EmailMessage.objects.count()
+
+        # Create the new evidence file to upload
+        new_evidence_file = SimpleUploadedFile(
+            "file2.txt", b"file_content2", content_type="text/plain"
+        )
+        ef1_sha1 = "2196496b4e89e354291719e76978ac7540d7adf5"
+
+        # Prepare the payload used to create the initial event
+        json_data = {
+            "date": "2026-04-28T13:43",
+            "priority": self.priority_url,
+            "tlp": self.tlp_url,
+            "taxonomy": self.taxonomy_url,
+            "feed": self.feed_url,
+            "address_value": "test.com",
+            "avoid_auto_merge": "true",
+            "evidence": new_evidence_file,
+        }
+
+        # Create the initial event using multipart form data
+        response = self.client.post(self.url_list, data=json_data, format="multipart")
+        event_uuid = response.data["uuid"]
+        event_id = response.data["url"].split("/")[-2]
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(EmailMessage.objects.count(), initial_count)
+
+        # Create a case and assign the event to it
+        self.case = Case.objects.create(
+            priority=self.priority,
+            tlp=self.tlp,
+            state=State.objects.get(name="Open"),
+        )
+        self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
+
+        event = Event.objects.get(pk=event_id)
+        event.case = self.case
+        event.save()
+
+        self.assertEqual(EmailMessage.objects.count(), initial_count + 3)
+        last_email = EmailMessage.objects.last()
+        self.assertEqual(len(last_email.attachments), 1)
+        first_attachment = EmailMessage.objects.last().attachments[0]
+        self.assertIn(ef1_sha1, first_attachment["name"])
+
+        # Add a new evidence file to the event
+        another_evidence_file = SimpleUploadedFile(
+            "file3.txt", b"file_content3", content_type="text/plain"
+        )
+        ef2_sha1 = "676640c7903a09368d69757973d15848930c64a1"
+        json_data_update = {
+            "date": "2026-04-28T13:43",
+            "priority": self.priority_url,
+            "tlp": self.tlp_url,
+            "taxonomy": self.taxonomy_url,
+            "feed": self.feed_url,
+            "address_value": "test.com",
+            "avoid_auto_merge": "true",
+            "evidence": another_evidence_file,
+        }
+        response_update = self.client.put(
+            self.url_detail(event_id), data=json_data_update, format="multipart"
+        )
+        self.assertEqual(response_update.status_code, status.HTTP_200_OK)
+
+        # Verify that an email was sent after adding the new evidence and that it includes the attachment
+        self.assertEqual(EmailMessage.objects.count(), initial_count + 5)
+
+        last_email = EmailMessage.objects.last()
+        self.assertEqual(len(last_email.attachments), 2)
+        second_attachment = last_email.attachments[1]
+        first_attachment = EmailMessage.objects.last().attachments[0]
+        self.assertIn(ef1_sha1, first_attachment["name"])
+        self.assertIn(ef2_sha1, second_attachment["name"])
+        self.assertIn(event_uuid, first_attachment["name"])
+        self.assertIn(event_uuid, second_attachment["name"])

--- a/ngen/tests/models/test_announcement.py
+++ b/ngen/tests/models/test_announcement.py
@@ -634,13 +634,15 @@ class AnnouncementTestCase(TestCase):
 
         # Assert email was sent in intern channel
         self.assertIsNotNone(intern_channel)
-        self.assertEqual(len(intern_channel.get_messages()), 1)
-        self.assertIn("open", intern_channel.get_last_message().body.lower())
+        self.assertEqual(len(intern_channel.get_messages()), 2)
+        self.assertIn("open", intern_channel.get_messages()[0].body.lower())
+        self.assertIn("team", intern_channel.get_messages()[1].body.lower())
 
         # Assert email was sent in affected channel
         self.assertIsNotNone(affected_channel)
-        self.assertEqual(len(affected_channel.get_messages()), 1)
-        self.assertIn("open", affected_channel.get_last_message().body.lower())
+        self.assertEqual(len(affected_channel.get_messages()), 2)
+        self.assertIn("open", affected_channel.get_messages()[0].body.lower())
+        self.assertIn("team", affected_channel.get_messages()[1].body.lower())
 
         expected_evidence_name = (
             f"Event({self.event.uuid})_{self.event.created.date()}_{evidence.filename}"
@@ -714,13 +716,15 @@ class AnnouncementTestCase(TestCase):
 
         # Assert email was sent in intern channel
         self.assertIsNotNone(intern_channel)
-        self.assertEqual(len(intern_channel.get_messages()), 1)
-        self.assertIn("open", intern_channel.get_last_message().body.lower())
+        self.assertEqual(len(intern_channel.get_messages()), 2)
+        self.assertIn("open", intern_channel.get_messages()[0].body.lower())
+        self.assertIn("team", intern_channel.get_messages()[1].body.lower())
 
         # Assert email was sent in affected channel
         self.assertIsNotNone(affected_channel)
-        self.assertEqual(len(affected_channel.get_messages()), 1)
-        self.assertIn("open", affected_channel.get_last_message().body.lower())
+        self.assertEqual(len(affected_channel.get_messages()), 2)
+        self.assertIn("open", affected_channel.get_messages()[0].body.lower())
+        self.assertIn("team", affected_channel.get_messages()[1].body.lower())
 
         expected_evidence_name = f"Event({self.event.uuid})_{self.event.created.date()}_EjemploEvidenciá-test-1_{evidence.filename}"
 


### PR DESCRIPTION
This pull request introduces a new feature for notifying users when evidence is added to cases or events, along with several related updates across the codebase and translation files. It also includes minor improvements to email template validation, new email templates, and updates to Spanish translations and test data.

**New evidence notification feature:**

* Added logic in the `CaseEvidence.save` method to send notifications when new evidence is added to a case or event. The notification uses new email templates and is triggered only on evidence creation.
* Registered new email templates (`new_evidence_added_to_event` and `new_evidence_added_to_case`) in the `EMAIL_TEMPLATES` mapping in `email_handler.py`.
* Added corresponding HTML templates for the new evidence notification emails: `new_evidence_added_to_case.html` and `new_evidence_added_to_event.html`. [[1]](diffhunk://#diff-87b43bfa2bdbc209976c49b2651a82c3ab33d5192bb2f20abf3bc5eabfd18424R1-R17) [[2]](diffhunk://#diff-12e28ca3835e1ba3676c93be3d54045151a70a3bd47549ebb6c4ae9adceec543R1-R20)
* Updated Spanish translation file (`django.po`) with new strings and translations for the evidence notification feature.

**Improvements and fixes:**

* Improved error messaging in `send_email` by including the invalid template name in the exception.
* Updated various translation strings and line references in the Spanish locale file to reflect recent code changes and improve consistency. [[1]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L5-R5) [[2]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L67-R138) [[3]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L229-R239) [[4]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L302-R312) [[5]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L345-R356) [[6]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L422-R433) [[7]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L435-R446) [[8]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L551-R578) [[9]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13R597-R601) [[10]](diffhunk://#diff-0cf5276bac19ece8c8fd83b19ca165266604c9c454bc402a974d59e491c8ff13L722-R839)

**Testing and test data updates:**

* Updated test imports and fixtures to support email testing and artifact uploads. [[1]](diffhunk://#diff-81dd8c579e7db4bb57e68bfd8f0e5f84fd8fd2f92b8f32713a23c16b4d567de7R4-R7) [[2]](diffhunk://#diff-81dd8c579e7db4bb57e68bfd8f0e5f84fd8fd2f92b8f32713a23c16b4d567de7R23-R24)
* Changed test data for event notes in multiple test cases from Spanish to English to maintain consistency. [[1]](diffhunk://#diff-81dd8c579e7db4bb57e68bfd8f0e5f84fd8fd2f92b8f32713a23c16b4d567de7L125-R131) [[2]](diffhunk://#diff-81dd8c579e7db4bb57e68bfd8f0e5f84fd8fd2f92b8f32713a23c16b4d567de7L141-R147) [[3]](diffhunk://#diff-81dd8c579e7db4bb57e68bfd8f0e5f84fd8fd2f92b8f32713a23c16b4d567de7L157-R163) [[4]](diffhunk://#diff-81dd8c579e7db4bb57e68bfd8f0e5f84fd8fd2f92b8f32713a23c16b4d567de7L177-R183) [[5]](diffhunk://#diff-81dd8c579e7db4bb57e68bfd8f0e5f84fd8fd2f92b8f32713a23c16b4d567de7L197-R203)