### PR TITLE
Fix: Avoid raise condition con sending email inside atomic transaction

### DIFF
--- a/ngen/mailer/email_handler.py
+++ b/ngen/mailer/email_handler.py
@@ -224,6 +224,7 @@ class EmailHandler:
                 attachments=attachments if attachments else [],
             )
 
-            async_send_email.delay(email_message.id)
+            email_id = email_message.id
+            transaction.on_commit(lambda: async_send_email.delay(email_id))
 
         return email_message

--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -441,6 +441,7 @@ def async_send_email(self, email_message_id: int):
         email_message = ngen.models.EmailMessage.objects.get(id=email_message_id)
     except ngen.models.EmailMessage.DoesNotExist as e:
         if self.request.retries == self.max_retries:
+            logger.error(f"EmailMessage {email_message_id} not found after {self.max_retries} retries.")
             return {"status": "error", "message": f"Email {email_message_id} not found"}
 
         exponential_backoff = (self.request.retries + 1) ** 2

--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -441,7 +441,7 @@ def async_send_email(self, email_message_id: int):
         email_message = ngen.models.EmailMessage.objects.get(id=email_message_id)
     except ngen.models.EmailMessage.DoesNotExist as e:
         if self.request.retries == self.max_retries:
-            logger.error(f"EmailMessage {email_message_id} not found after {self.max_retries} retries.")
+            logger.exception(f"EmailMessage {email_message_id} not found after {self.max_retries} retries.")
             return {"status": "error", "message": f"Email {email_message_id} not found"}
 
         exponential_backoff = (self.request.retries + 1) ** 2
@@ -494,6 +494,7 @@ def async_send_email(self, email_message_id: int):
         return {"status": "success", "message": f"Email {email_message_id} sent"}
     except Exception as e:
         email_message.send_attempt_failed = True
+        logger.exception(f"Error sending email {email_message_id}: {str(e)}")
         raise e
     finally:
         email_message.save()

--- a/ngen/tests/api/test_communication_channel_communicate.py
+++ b/ngen/tests/api/test_communication_channel_communicate.py
@@ -82,9 +82,10 @@ class TestCommunicationChannelCommunicate(APITestCaseWithLogin):
         ]
         params = {"subject": "Test Subject", "body": "Test Body"}
 
-        response = self.client.post(
-            self.url_communicate(self.communication_channel.id), data=params
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_communicate(self.communication_channel.id), data=params
+            )
 
         self.communication_channel.refresh_from_db()
         created_email_message = EmailMessage.objects.get(id=response.data["id"])
@@ -155,9 +156,10 @@ class TestCommunicationChannelCommunicate(APITestCaseWithLogin):
         ]
         params = {"body": "Test Body"}
 
-        response = self.client.post(
-            self.url_communicate(self.communication_channel.id), data=params
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_communicate(self.communication_channel.id), data=params
+            )
 
         self.communication_channel.refresh_from_db()
         created_email_message = EmailMessage.objects.get(id=response.data["id"])
@@ -202,11 +204,12 @@ class TestCommunicationChannelCommunicate(APITestCaseWithLogin):
             "body": "Test Body",
         }
 
-        response = self.client.post(
-            self.url_communicate(self.communication_channel.id),
-            data=json.dumps(params),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_communicate(self.communication_channel.id),
+                data=json.dumps(params),
+                content_type="application/json",
+            )
 
         self.communication_channel.refresh_from_db()
         created_email_message = EmailMessage.objects.get(id=response.data["id"])
@@ -239,9 +242,11 @@ class TestCommunicationChannelCommunicate(APITestCaseWithLogin):
 
         params = {"subject": "Test Subject"}
 
-        response = self.client.post(
-            self.url_communicate(self.communication_channel.id), data=params
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_communicate(self.communication_channel.id),
+                data=params
+            )
 
         response_messages = self.get_messages_from_response(response)
 

--- a/ngen/tests/api/test_emailmessage.py
+++ b/ngen/tests/api/test_emailmessage.py
@@ -153,7 +153,8 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(self.url_send_email, data=json_data)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(self.url_send_email, data=json_data)
 
         response_messages = self.get_messages_from_response(response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -175,7 +176,8 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(self.url_send_email, data=json_data)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(self.url_send_email, data=json_data)
 
         response_messages = self.get_messages_from_response(response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -199,11 +201,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Respondiendo al primer email",
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         response_messages = self.get_messages_from_response(response)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -228,11 +231,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         response_messages = self.get_messages_from_response(response)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -254,11 +258,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         response_messages = self.get_messages_from_response(response)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -281,11 +286,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "in_reply_to": 9999,
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         response_messages = self.get_messages_from_response(response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -306,11 +312,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
 
@@ -331,11 +338,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -362,11 +370,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -414,11 +423,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "in_reply_to": email_message.id,
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -492,11 +502,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "in_reply_to": email_messages[1].id,
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -539,11 +550,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "template_params": {"param1": "value1", "param2": "value2"},
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -570,11 +582,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             "body": "Test body",
         }
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -611,11 +624,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             {"name": "victim2", "email": "victim2@organization2.com"},
         ]
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -672,11 +686,12 @@ class TestEmailMessage(APITestCaseWithLogin):
             {"name": "Another Recipient", "email": "another_recipient@org.com"},
         ]
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)
@@ -715,11 +730,12 @@ class TestEmailMessage(APITestCaseWithLogin):
 
         initial_count = EmailMessage.objects.count()
 
-        response = self.client.post(
-            self.url_send_email,
-            data=json.dumps(json_data),
-            content_type="application/json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.url_send_email,
+                data=json.dumps(json_data),
+                content_type="application/json",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(EmailMessage.objects.count(), initial_count + 1)


### PR DESCRIPTION
This pull request makes improvements to the email sending workflow to ensure more reliable task execution and better error logging. The main changes focus on deferring the asynchronous email sending task until after the database transaction is committed, and enhancing error reporting for missing email messages.

**Email sending workflow improvements:**

* In `email_handler.py`, the call to `async_send_email.delay` is now wrapped in a `transaction.on_commit` callback to ensure the task is only triggered after the email message is successfully saved to the database. This prevents race conditions where the task could run before the email message exists.

**Error handling and logging:**

* In `tasks.py`, improved error logging for missing `EmailMessage` objects: if the message is not found after the maximum number of retries, an error is logged with details, aiding in debugging and monitoring.