### PR TITLE
feature/sorted_summary

### DIFF
--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -157,7 +157,11 @@ def contact_summary(
                     min_domain=Min("events__domain"),
                     min_cidr=Min("events__cidr"),
                 )
-                .order_by("priority__severity", "min_domain", "min_cidr")
+                .order_by(
+                    "priority__severity",
+                    F("min_domain").asc(nulls_last=True),
+                    F("min_cidr").asc(nulls_last=True),
+                )
                 .distinct()
             )
             list_open_cases = [
@@ -177,7 +181,11 @@ def contact_summary(
                     min_domain=Min("events__domain"),
                     min_cidr=Min("events__cidr"),
                 )
-                .order_by("priority__severity", "min_domain", "min_cidr")
+                .order_by(
+                    "priority__severity",
+                    F("min_domain").asc(nulls_last=True),
+                    F("min_cidr").asc(nulls_last=True),
+                )
                 .distinct()
             )
 
@@ -345,7 +353,11 @@ def export_events_for_email_task(email, days=14):
                 min_domain=Min("events__domain"),
                 min_cidr=Min("events__cidr"),
             )
-            .order_by("priority__severity", "min_domain", "min_cidr")
+            .order_by(
+                "priority__severity",
+                F("min_domain").asc(nulls_last=True),
+                F("min_cidr").asc(nulls_last=True),
+            )
             .distinct()
         )
 
@@ -371,7 +383,11 @@ def export_events_for_email_task(email, days=14):
                 min_domain=Min("events__domain"),
                 min_cidr=Min("events__cidr"),
             )
-            .order_by("priority__severity", "min_domain", "min_cidr")
+            .order_by(
+                "priority__severity",
+                F("min_domain").asc(nulls_last=True),
+                F("min_cidr").asc(nulls_last=True),
+            )
             .distinct()
         )
 

--- a/ngen/tasks.py
+++ b/ngen/tasks.py
@@ -4,7 +4,7 @@ import logging
 from os import path
 from celery import shared_task
 from django_celery_beat.models import PeriodicTask
-from django.db.models import F, DateTimeField, ExpressionWrapper, DurationField
+from django.db.models import F, Min, DateTimeField, ExpressionWrapper, DurationField
 from django.conf import settings
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
@@ -153,7 +153,11 @@ def contact_summary(
                     state__attended=True, events__network__contacts=contact
                 )
                 .prefetch_related("events")
-                .order_by("priority__severity")
+                .annotate(
+                    min_domain=Min("events__domain"),
+                    min_cidr=Min("events__cidr"),
+                )
+                .order_by("priority__severity", "min_domain", "min_cidr")
                 .distinct()
             )
             list_open_cases = [
@@ -169,6 +173,11 @@ def contact_summary(
                     solve_date__gte=timezone.now() - timedeltavalue,
                 )
                 .prefetch_related("events")
+                .annotate(
+                    min_domain=Min("events__domain"),
+                    min_cidr=Min("events__cidr"),
+                )
+                .order_by("priority__severity", "min_domain", "min_cidr")
                 .distinct()
             )
 
@@ -332,7 +341,11 @@ def export_events_for_email_task(email, days=14):
             ngen.models.Case.objects.filter(
                 state__attended=True, events__network__contacts=contact
             )
-            .prefetch_related("events")
+            .annotate(
+                min_domain=Min("events__domain"),
+                min_cidr=Min("events__cidr"),
+            )
+            .order_by("priority__severity", "min_domain", "min_cidr")
             .distinct()
         )
 
@@ -354,7 +367,11 @@ def export_events_for_email_task(email, days=14):
                 events__network__contacts=contact,
                 solve_date__gte=timezone.now() - timedeltavalue,
             )
-            .prefetch_related("events")
+            .annotate(
+                min_domain=Min("events__domain"),
+                min_cidr=Min("events__cidr"),
+            )
+            .order_by("priority__severity", "min_domain", "min_cidr")
             .distinct()
         )
 

--- a/ngen/tests/models/test_announcement.py
+++ b/ngen/tests/models/test_announcement.py
@@ -1633,3 +1633,241 @@ class AnnouncementTestCase(TestCase):
             )
 
         self.assertEqual(len(mail.outbox), 1 * len(contacts_with))
+
+    # --------------- SUMMARY ORDERING TESTS -----------------
+
+    @patch("django.core.mail.backends.smtp.EmailBackend")
+    @use_test_email_env()
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True, LANGUAGE_CODE="en")
+    @override_config(CASE_REPORT_NEW_CASES=True)
+    @override_config(TEAM_EMAIL="team@ngen.com")
+    @override_config(SUMMARY_TLP="green")
+    @override_config(TEAM_NAME="TEAM")
+    @override_config(NGEN_LANG="en")
+    def test_summary_open_cases_ordered_by_priority_then_address(self, mock_backend):
+        """
+        Open cases in the summary should be ordered by priority (severity asc)
+        first, then by address (alphabetically by address_value).
+        """
+        from django.utils import translation
+
+        translation.activate("en")
+        self.addCleanup(translation.deactivate)
+
+        from django.core.mail import get_connection
+
+        mock_backend.return_value = get_connection(
+            "django.core.mail.backends.locmem.EmailBackend"
+        )
+
+        feed = Feed.objects.get(slug="csirtamericas")
+        taxonomy = Taxonomy.objects.get(slug="botnet")
+        tlp = Tlp.objects.get(slug="green")
+        reporter = User.objects.get(username="ngen")
+
+        # Create 4 cases with different priorities and addresses
+        # Priority severities: Critical(1), High(2), Medium(3), Low(4)
+        # Domains used: host_a < host_b < host_c < host_d alphabetically
+
+        # Case A: Medium(3), domain host_a.example.com
+        case_a = Case.objects.create(
+            state=State.objects.get(slug="open"),
+            tlp=tlp,
+            priority=Priority.objects.get(slug="medium"),
+        )
+        ev_a = Event.objects.create(
+            domain="host_a.example.com",
+            taxonomy=taxonomy,
+            feed=feed,
+            tlp=tlp,
+            reporter=reporter,
+            priority=Priority.objects.get(slug="medium"),
+            avoid_auto_merge=True,
+        )
+        ev_a.case = case_a
+        ev_a.save()
+
+        # Case B: High(2), domain host_b.example.com
+        case_b = Case.objects.create(
+            state=State.objects.get(slug="open"),
+            tlp=tlp,
+            priority=Priority.objects.get(slug="high"),
+        )
+        ev_b = Event.objects.create(
+            domain="host_b.example.com",
+            taxonomy=taxonomy,
+            feed=feed,
+            tlp=tlp,
+            reporter=reporter,
+            priority=Priority.objects.get(slug="high"),
+            avoid_auto_merge=True,
+        )
+        ev_b.case = case_b
+        ev_b.save()
+
+        # Case C: High(2), domain host_c.example.com (same priority as B, lower domain)
+        case_c = Case.objects.create(
+            state=State.objects.get(slug="open"),
+            tlp=tlp,
+            priority=Priority.objects.get(slug="high"),
+        )
+        ev_c = Event.objects.create(
+            domain="host_c.example.com",
+            taxonomy=taxonomy,
+            feed=feed,
+            tlp=tlp,
+            reporter=reporter,
+            priority=Priority.objects.get(slug="high"),
+            avoid_auto_merge=True,
+        )
+        ev_c.case = case_c
+        ev_c.save()
+
+        # Case D: Critical(1), domain host_d.example.com
+        case_d = Case.objects.create(
+            state=State.objects.get(slug="open"),
+            tlp=tlp,
+            priority=Priority.objects.get(slug="critical"),
+        )
+        ev_d = Event.objects.create(
+            domain="host_d.example.com",
+            taxonomy=taxonomy,
+            feed=feed,
+            tlp=tlp,
+            reporter=reporter,
+            priority=Priority.objects.get(slug="critical"),
+            avoid_auto_merge=True,
+        )
+        ev_d.case = case_d
+        ev_d.save()
+
+        tasks.contact_summary.delay(contact_usernames=["soporte@cert.unlp.edu.ar"])
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+
+        id_a = str(case_a.uuid).split("-")[0]
+        id_b = str(case_b.uuid).split("-")[0]
+        id_c = str(case_c.uuid).split("-")[0]
+        id_d = str(case_d.uuid).split("-")[0]
+
+        body = email.body
+
+        pos_a, pos_b = body.index(id_a), body.index(id_b)
+        pos_c, pos_d = body.index(id_c), body.index(id_d)
+
+        # Expected order by priority (severity asc): D(Critical=1), C(High=2), B(High=2), A(Medium=3)
+        # Within High: C (host_c.example.com) before B (host_b.example.com)
+        self.assertLess(pos_d, pos_c, "Critical should come before High")
+        self.assertLess(pos_c, pos_b, "Within High, lower domain should come first")
+        self.assertLess(pos_b, pos_a, "High should come before Medium")
+
+    @patch("django.core.mail.backends.smtp.EmailBackend")
+    @use_test_email_env()
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True, LANGUAGE_CODE="en")
+    @override_config(CASE_REPORT_NEW_CASES=True)
+    @override_config(TEAM_EMAIL="team@ngen.com")
+    @override_config(SUMMARY_TLP="green")
+    @override_config(TEAM_NAME="TEAM")
+    @override_config(NGEN_LANG="en")
+    def test_summary_closed_cases_ordered_by_priority_then_address(
+        self, mock_backend
+    ):
+        """
+        Closed cases in the summary should be ordered by priority (severity asc)
+        first, then by address (alphabetically).
+        """
+        from django.utils import translation
+
+        translation.activate("en")
+        self.addCleanup(translation.deactivate)
+
+        from django.core.mail import get_connection
+
+        mock_backend.return_value = get_connection(
+            "django.core.mail.backends.locmem.EmailBackend"
+        )
+
+        feed = Feed.objects.get(slug="csirtamericas")
+        taxonomy = Taxonomy.objects.get(slug="botnet")
+        tlp = Tlp.objects.get(slug="green")
+        reporter = User.objects.get(username="ngen")
+        closed_state = State.objects.get(slug="closed")
+
+        # Case X: Low(4), address aaa.example.com
+        case_x = Case.objects.create(
+            state=closed_state,
+            tlp=tlp,
+            priority=Priority.objects.get(slug="low"),
+        )
+        ev_x = Event.objects.create(
+            domain="aaa.example.com",
+            taxonomy=taxonomy,
+            feed=feed,
+            tlp=tlp,
+            reporter=reporter,
+            priority=Priority.objects.get(slug="low"),
+            avoid_auto_merge=True,
+        )
+        ev_x.case = case_x
+        ev_x.save()
+
+        # Case Y: Medium(3), address zzz.example.com
+        case_y = Case.objects.create(
+            state=closed_state,
+            tlp=tlp,
+            priority=Priority.objects.get(slug="medium"),
+        )
+        ev_y = Event.objects.create(
+            domain="zzz.example.com",
+            taxonomy=taxonomy,
+            feed=feed,
+            tlp=tlp,
+            reporter=reporter,
+            priority=Priority.objects.get(slug="medium"),
+            avoid_auto_merge=True,
+        )
+        ev_y.case = case_y
+        ev_y.save()
+
+        # Case Z: Medium(3), address mmm.example.com (same priority as Y, lower address)
+        case_z = Case.objects.create(
+            state=closed_state,
+            tlp=tlp,
+            priority=Priority.objects.get(slug="medium"),
+        )
+        ev_z = Event.objects.create(
+            domain="mmm.example.com",
+            taxonomy=taxonomy,
+            feed=feed,
+            tlp=tlp,
+            reporter=reporter,
+            priority=Priority.objects.get(slug="medium"),
+            avoid_auto_merge=True,
+        )
+        ev_z.case = case_z
+        ev_z.save()
+
+        tasks.contact_summary.delay(contact_usernames=["soporte@cert.unlp.edu.ar"])
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+
+        id_x = str(case_x.uuid).split("-")[0]
+        id_y = str(case_y.uuid).split("-")[0]
+        id_z = str(case_z.uuid).split("-")[0]
+
+        body = email.body
+
+        # All three should appear
+        self.assertIn(id_x, body)
+        self.assertIn(id_y, body)
+        self.assertIn(id_z, body)
+
+        pos_x = body.index(id_x)
+        pos_y = body.index(id_y)
+        pos_z = body.index(id_z)
+
+        # Expected order by priority (severity asc): Z(Medium=3 mmm), Y(Medium=3 zzz), X(Low=4)
+        self.assertLess(pos_z, pos_y, "Within Medium, lower domain should come first")
+        self.assertLess(pos_y, pos_x, "Medium should come before Low")

--- a/ngen/tests/models/test_announcement.py
+++ b/ngen/tests/models/test_announcement.py
@@ -1647,7 +1647,7 @@ class AnnouncementTestCase(TestCase):
     def test_summary_open_cases_ordered_by_priority_then_address(self, mock_backend):
         """
         Open cases in the summary should be ordered by priority (severity asc)
-        first, then by address (alphabetically by address_value).
+        first, then by domain (alphabetically) and CIDR.
         """
         from django.utils import translation
 
@@ -1714,7 +1714,7 @@ class AnnouncementTestCase(TestCase):
         ev_b.case = case_b
         ev_b.save()
 
-        # Case C: High(2), domain host-c.example.com (same priority as B, lower domain)
+        # Case C: High(2), domain host-c.example.com (same priority as B, comes after B alphabetically)
         case_c = Case.objects.create(
             state=State.objects.get(slug="open"),
             tlp=tlp,
@@ -1784,7 +1784,7 @@ class AnnouncementTestCase(TestCase):
     ):
         """
         Closed cases in the summary should be ordered by priority (severity asc)
-        first, then by address (alphabetically).
+        first, then by domain (alphabetically) and CIDR.
         """
         from django.utils import translation
 

--- a/ngen/tests/models/test_announcement.py
+++ b/ngen/tests/models/test_announcement.py
@@ -1636,7 +1636,7 @@ class AnnouncementTestCase(TestCase):
 
     # --------------- SUMMARY ORDERING TESTS -----------------
 
-    @patch("django.core.mail.backends.smtp.EmailBackend")
+    @patch("ngen.tasks.EmailBackend")
     @use_test_email_env()
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True, LANGUAGE_CODE="en")
     @override_config(CASE_REPORT_NEW_CASES=True)
@@ -1665,18 +1665,27 @@ class AnnouncementTestCase(TestCase):
         tlp = Tlp.objects.get(slug="green")
         reporter = User.objects.get(username="ngen")
 
+        # Create network for the test domain
+        net = Network.objects.create(
+            domain="example.com",
+            active=True,
+            type="internal",
+            parent=self.network,
+        )
+        net.contacts.set([self.contact])
+
         # Create 4 cases with different priorities and addresses
         # Priority severities: Critical(1), High(2), Medium(3), Low(4)
-        # Domains used: host_a < host_b < host_c < host_d alphabetically
+        # Domains used: host-a < host-b < host-c < host-d alphabetically
 
-        # Case A: Medium(3), domain host_a.example.com
+        # Case A: Medium(3), domain host-a.example.com
         case_a = Case.objects.create(
             state=State.objects.get(slug="open"),
             tlp=tlp,
             priority=Priority.objects.get(slug="medium"),
         )
         ev_a = Event.objects.create(
-            domain="host_a.example.com",
+            domain="host-a.example.com",
             taxonomy=taxonomy,
             feed=feed,
             tlp=tlp,
@@ -1687,14 +1696,14 @@ class AnnouncementTestCase(TestCase):
         ev_a.case = case_a
         ev_a.save()
 
-        # Case B: High(2), domain host_b.example.com
+        # Case B: High(2), domain host-b.example.com
         case_b = Case.objects.create(
             state=State.objects.get(slug="open"),
             tlp=tlp,
             priority=Priority.objects.get(slug="high"),
         )
         ev_b = Event.objects.create(
-            domain="host_b.example.com",
+            domain="host-b.example.com",
             taxonomy=taxonomy,
             feed=feed,
             tlp=tlp,
@@ -1705,14 +1714,14 @@ class AnnouncementTestCase(TestCase):
         ev_b.case = case_b
         ev_b.save()
 
-        # Case C: High(2), domain host_c.example.com (same priority as B, lower domain)
+        # Case C: High(2), domain host-c.example.com (same priority as B, lower domain)
         case_c = Case.objects.create(
             state=State.objects.get(slug="open"),
             tlp=tlp,
             priority=Priority.objects.get(slug="high"),
         )
         ev_c = Event.objects.create(
-            domain="host_c.example.com",
+            domain="host-c.example.com",
             taxonomy=taxonomy,
             feed=feed,
             tlp=tlp,
@@ -1723,14 +1732,14 @@ class AnnouncementTestCase(TestCase):
         ev_c.case = case_c
         ev_c.save()
 
-        # Case D: Critical(1), domain host_d.example.com
+        # Case D: Critical(1), domain host-d.example.com
         case_d = Case.objects.create(
             state=State.objects.get(slug="open"),
             tlp=tlp,
             priority=Priority.objects.get(slug="critical"),
         )
         ev_d = Event.objects.create(
-            domain="host_d.example.com",
+            domain="host-d.example.com",
             taxonomy=taxonomy,
             feed=feed,
             tlp=tlp,
@@ -1756,13 +1765,13 @@ class AnnouncementTestCase(TestCase):
         pos_a, pos_b = body.index(id_a), body.index(id_b)
         pos_c, pos_d = body.index(id_c), body.index(id_d)
 
-        # Expected order by priority (severity asc): D(Critical=1), C(High=2), B(High=2), A(Medium=3)
-        # Within High: C (host_c.example.com) before B (host_b.example.com)
-        self.assertLess(pos_d, pos_c, "Critical should come before High")
-        self.assertLess(pos_c, pos_b, "Within High, lower domain should come first")
-        self.assertLess(pos_b, pos_a, "High should come before Medium")
+        # Expected order by priority (severity asc): D(Critical=1), B(High=2), C(High=2), A(Medium=3)
+        # Within High: B (host-b.example.com) before C (host-c.example.com)
+        self.assertLess(pos_d, pos_b, "Critical should come before High")
+        self.assertLess(pos_b, pos_c, "Within High, lower domain should come first")
+        self.assertLess(pos_c, pos_a, "High should come before Medium")
 
-    @patch("django.core.mail.backends.smtp.EmailBackend")
+    @patch("ngen.tasks.EmailBackend")
     @use_test_email_env()
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True, LANGUAGE_CODE="en")
     @override_config(CASE_REPORT_NEW_CASES=True)
@@ -1793,6 +1802,15 @@ class AnnouncementTestCase(TestCase):
         tlp = Tlp.objects.get(slug="green")
         reporter = User.objects.get(username="ngen")
         closed_state = State.objects.get(slug="closed")
+
+        # Create network for the test domain
+        net = Network.objects.create(
+            domain="example.com",
+            active=True,
+            type="internal",
+            parent=self.network,
+        )
+        net.contacts.set([self.contact])
 
         # Case X: Low(4), address aaa.example.com
         case_x = Case.objects.create(


### PR DESCRIPTION
This pull request enhances the ordering of cases in summary emails to ensure they are sorted first by priority (severity ascending), and then by address (alphabetically by domain or CIDR). It also introduces comprehensive tests to verify this new ordering for both open and closed cases.

Ordering improvements in summary tasks:

* Updated queries in `ngen/tasks.py` to annotate cases with the minimum domain and CIDR from related events, and to order by `priority__severity`, then by `min_domain`, and then by `min_cidr` for both open and closed cases in the `contact_summary` and `export_events_for_email_task` functions. [[1]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387L156-R160) [[2]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387R176-R180) [[3]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387L335-R348) [[4]](diffhunk://#diff-0b96481130e90f80957fbd8a97be3dc474d6fb7aa1cf0cc7300810a1f770a387L357-R374)
* Added `Min` import from `django.db.models` to support the new annotations.

Testing enhancements:

* Added two new test methods in `ngen/tests/models/test_announcement.py` to verify that open and closed case summaries are correctly ordered by priority and address, including edge cases with equal priorities and different addresses.